### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [HIGH] Fix Profiling Endpoint Exposure
+**Vulnerability:** The application was automatically exposing profiling endpoints (`/debug/pprof/*`) on `http.DefaultServeMux` due to the `_ "net/http/pprof"` import in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This is a CWE-200 vulnerability that could leak sensitive internal runtime metrics, memory allocations, and environment information to an attacker.
+**Learning:** In Go, importing `net/http/pprof` in this manner automatically registers profiling endpoints to the default HTTP multiplexer. This is a common Information Disclosure vulnerability if the default multiplexer is exposed to untrusted networks.
+**Prevention:** Avoid using the anonymous `_ "net/http/pprof"` import in production binaries. If profiling is needed, explicitly register it onto a secure, internal-only HTTP server rather than accidentally exposing it on the main server.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was automatically exposing profiling endpoints (`/debug/pprof/*`) on `http.DefaultServeMux` due to the `_ "net/http/pprof"` import in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This is a CWE-200 vulnerability.
🎯 **Impact:** If `http.DefaultServeMux` is exposed to untrusted networks, an attacker could access sensitive internal runtime metrics, memory allocations, and environment information.
🔧 **Fix:** Removed the anonymous `_ "net/http/pprof"` imports from the `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go` production binaries.
✅ **Verification:** Verified that the imports are removed and the binaries compile correctly without automatically registering profiling endpoints to the default HTTP multiplexer.

---
*PR created automatically by Jules for task [7582584435963295551](https://jules.google.com/task/7582584435963295551) started by @phbnf*