### PR TITLE
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Fix profiling endpoint exposure (CWE-200)]
+**Vulnerability:** Unintentional exposure of the `net/http/pprof` profiling endpoint on `http.DefaultServeMux`.
+**Learning:** The `_ "net/http/pprof"` import implicitly attaches its debug handlers (e.g., `/debug/pprof/`) to the default HTTP multiplexer (`http.DefaultServeMux`). If `http.DefaultServeMux` is directly or indirectly exposed, an attacker can access sensitive runtime information.
+**Prevention:** Do not use `_ "net/http/pprof"` in production endpoints unless heavily restricted (e.g., authentication or an isolated internal port). The project uses OpenTelemetry for instrumentation instead.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unintentional exposure of the `net/http/pprof` profiling endpoint on `http.DefaultServeMux` (CWE-200).
🎯 **Impact:** If `http.DefaultServeMux` is exposed directly or indirectly, attackers could access sensitive runtime application data, memory allocation information, and goroutine details via the `/debug/pprof/` endpoints.
🔧 **Fix:** Removed the `_ "net/http/pprof"` blank import from the `posix` and `gcp` binary entry points. The application rightly uses OpenTelemetry for internal metrics tracking, so this generic pprof hook is not only risky but unnecessary for standard production use. Added a learning to `.jules/sentinel.md`.
✅ **Verification:** Verified that the project still successfully builds (`go build ./cmd/tesseract/...`) and that all existing tests pass (`go test ./...`). Without the blank import, the standard HTTP profiling debug routes are no longer implicitly registered to the default mux.

---
*PR created automatically by Jules for task [3357372587232488726](https://jules.google.com/task/3357372587232488726) started by @phbnf*