### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `net/http/pprof` was anonymously imported in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This automatically registers `pprof` handlers to the global `http.DefaultServeMux`. If an HTTP server uses this default multiplexer, debugging endpoints (like `/debug/pprof/`) are exposed.
🎯 Impact: This exposes sensitive runtime debugging data (memory usage, goroutines, command-line arguments) to anyone who can access the HTTP server, causing an information disclosure vulnerability (CWE-200), and potentially allowing Denial of Service attacks via expensive CPU profiles.
🔧 Fix: Removed the anonymous imports of `_ "net/http/pprof"` from both files.
✅ Verification: Ran `gosec ./...` and verified that the G108 rules no longer alert on these two files. Compiled the binaries and verified that no build issues were introduced.

---
*PR created automatically by Jules for task [2944722468565024125](https://jules.google.com/task/2944722468565024125) started by @phbnf*