### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-16 - Prevent Profiling Endpoint Exposure
+**Vulnerability:** Automatic exposure of `net/http/pprof` endpoints (`/debug/pprof`) via anonymous import.
+**Learning:** In Go, anonymously importing `net/http/pprof` automatically registers profiling handlers on `http.DefaultServeMux`. If a public HTTP server uses the default mux, it exposes sensitive application internals (memory, CPU, command-line arguments, goroutines) and creates a potential Denial of Service (DoS) and Information Leakage (CWE-200) vector.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` in production-facing binaries (like AWS/GCP/POSIX cloud personalities). If profiling is needed, register it explicitly on a separate, internal-only `ServeMux` protected by authentication or a private network interface.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Automatic exposure of `net/http/pprof` endpoints (`/debug/pprof`) on the default HTTP server multiplexer via anonymous import.
🎯 Impact: If the default HTTP serve mux is exposed publicly, attackers can access sensitive application profiling data, including memory maps, CPU profiles, goroutine stacks, and command-line arguments. This can be leveraged to understand application internals (CWE-200) or to mount Denial of Service (DoS) attacks by triggering computationally expensive profiling tasks remotely.
🔧 Fix: Removed the `_ "net/http/pprof"` import from the GCP and POSIX cloud personality main entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`).
✅ Verification: `gosec` SAST scanning no longer flags G108 for these files. All tests pass successfully (`go test ./...`).

---
*PR created automatically by Jules for task [11091450058733340891](https://jules.google.com/task/11091450058733340891) started by @phbnf*