### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-17 - [Sentinel] Fix CWE-200
+**Vulnerability:** Profiling endpoints automatically exposed on HTTP default serve mux (CWE-200) due to importing _ "net/http/pprof" in public-facing custom multiplexers in AWS/GCP binaries.
+**Learning:** When mitigating global http.DefaultServeMux exposure, be careful not to inadvertently import and expose net/http/pprof on public-facing custom multiplexers, as this introduces CWE-200 (profiling endpoint exposure).
+**Prevention:** Avoid importing _ "net/http/pprof" in public-facing HTTP server binaries to prevent inadvertent exposure of profiling endpoints.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Importing `_ "net/http/pprof"` automatically exposes profiling endpoints (`/debug/pprof/*`) on `http.DefaultServeMux`. For public-facing endpoints (like the GCP and POSIX HTTP servers), this can lead to Information Exposure (CWE-200) or Denial of Service.
🎯 Impact: Attackers could gain insights into application memory, CPU usage, and potentially goroutines, exposing internal application state. It also offers vectors for algorithmic complexity attacks.
🔧 Fix: Removed the blank imports (`_ "net/http/pprof"`) from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
✅ Verification: Ran `gosec` to verify that the `G108` (CWE-200) issue is no longer reported, and verified using `grep` that the imports are gone. All existing tests pass.

---
*PR created automatically by Jules for task [5847633017070156317](https://jules.google.com/task/5847633017070156317) started by @phbnf*