### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Automatic exposure of `net/http/pprof` endpoints via `_ "net/http/pprof"` imports in the `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go` entry points.
🎯 Impact: Attackers can access `/debug/pprof/*` endpoints on the default HTTP multiplexer, leaking sensitive internal runtime metrics, environment data, and memory/CPU profiles. This can also be abused to cause Denial of Service (DoS) by triggering continuous profiling.
🔧 Fix: Removed the blank import of `net/http/pprof` from the affected entry points to prevent the endpoints from being registered globally on `http.DefaultServeMux`.
✅ Verification: Ran `go test ./...` and `go build ./...` successfully. To manually verify, one could run the compiled binaries and ensure `/debug/pprof` endpoints return a 404 instead of profiling data.

---
*PR created automatically by Jules for task [11485399639271281061](https://jules.google.com/task/11485399639271281061) started by @phbnf*