### PR TITLE
🛡️ Sentinel: [HIGH] Fix unintended exposure of pprof profiling endpoints

### DIFF
--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
## Sentinel Security Fix

**🚨 Severity:** HIGH
**💡 Vulnerability:** Unintended exposure of profiling endpoints (CWE-200) via `net/http/pprof` side-effect imports on the global `http.DefaultServeMux`.
**🎯 Impact:** Unauthorized users could access application internals, memory profiles, and goroutine traces, leading to information disclosure and potential Denial of Service.
**🔧 Fix:** Removed the `_ "net/http/pprof"` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
**✅ Verification:** Ran `go test ./...` and `go vet ./...` to verify no regressions. Code review confirmed the fix is correct and safe.

---
*PR created automatically by Jules for task [13248563632518232068](https://jules.google.com/task/13248563632518232068) started by @phbnf*