### PR TITLE
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-20 - [Remove net/http/pprof to prevent profiling endpoint exposure]
+**Vulnerability:** Profiling endpoint is automatically exposed on /debug/pprof because of `_ "net/http/pprof"` import.
+**Learning:** Importing `_ "net/http/pprof"` automatically registers profiling handlers on `http.DefaultServeMux`, which exposes them on the main HTTP server without authentication.
+**Prevention:** Avoid importing `_ "net/http/pprof"` in production binaries. If profiling is needed, register pprof handlers on a separate, internal port or add authentication.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Profiling endpoints automatically exposed via `_ "net/http/pprof"` on `http.DefaultServeMux` (CWE-200).
🎯 Impact: Attackers can access sensitive internal metrics, stack traces, and memory profiles via the public-facing HTTP server, causing information disclosure or potential DoS.
🔧 Fix: Removed the blank import of `net/http/pprof` in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Documented the learning in `.jules/sentinel.md`.
✅ Verification: Ran `gosec ./...` and verified that the G108 finding is eliminated. Verified full test suite still passes.

---
*PR created automatically by Jules for task [8870323400814969641](https://jules.google.com/task/8870323400814969641) started by @phbnf*