### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling Endpoint Exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-22 - [CWE-200] Exposure of Profiling Endpoint
+**Vulnerability:** The profiling endpoint `/debug/pprof` was exposed automatically in the main HTTP servers (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`).
+**Learning:** The blank import `_ "net/http/pprof"` automatically registers its profiling handlers on the global `http.DefaultServeMux`. If an application relies on `http.Handle` (which also attaches to `DefaultServeMux`), those sensitive profiling endpoints will be publicly accessible on the internet, leaking internal application state and potentially introducing denial of service vectors.
+**Prevention:** Avoid the blank import of `net/http/pprof` in any binary that starts a public-facing HTTP server using the default mux. If profiling is needed, register pprof handlers on a separate, internal-only `http.ServeMux` instead.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The profiling endpoint `/debug/pprof/*` was exposed automatically in the main HTTP servers (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`) because of the blank import `_ "net/http/pprof"`. Because `http.Handle` attaches handlers to the global `http.DefaultServeMux`, the pprof endpoints were inadvertently made publicly accessible.
🎯 Impact: This exposes sensitive server internals such as memory allocation, CPU profiles, and running goroutines. This information leak could aid an attacker in crafting specific attacks or trigger a Denial of Service.
🔧 Fix: Removed the blank import of `net/http/pprof` from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. Also documented the finding in `.jules/sentinel.md`.
✅ Verification: `go test ./...` passes. `gosec ./...` confirms the `G108` issues have been resolved.

---
*PR created automatically by Jules for task [1086199025614304312](https://jules.google.com/task/1086199025614304312) started by @phbnf*