### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of profiling endpoints via pprof import

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,12 @@
+## 2026-03-23 - Inadvertent Exposure of Profiling Endpoints via pprof Import
+
+**Vulnerability:**
+The `net/http/pprof` package was imported for side-effects (`_ "net/http/pprof"`) in the main entrypoints (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`). This automatically registers profiling endpoints (`/debug/pprof/*`) on `http.DefaultServeMux`, leading to a CWE-200 vulnerability (exposure of sensitive system information like memory profiles, CPU profiles, and goroutine stacks).
+
+**Learning:**
+Importing `net/http/pprof` for its side-effects is dangerous in binaries that serve public traffic on or potentially fallback to `http.DefaultServeMux`. Even if the primary application handler doesn't explicitly use `DefaultServeMux`, inadvertent use or misconfiguration elsewhere can inadvertently expose these endpoints. Profiling should be handled intentionally, ideally on a separate internal port, or restricted via authentication and network policies.
+
+**Prevention:**
+- Never use the side-effect import `_ "net/http/pprof"` in production binaries.
+- If profiling is required, manually register pprof handlers on a dedicated, non-public multiplexer that is only accessible internally or requires authentication.
+- Utilize security scanning tools like `gosec` (which identifies this issue as G108) during CI to catch inadvertent pprof imports before they reach production.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application entrypoints (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`) inadvertently imported `net/http/pprof` for side-effects. This automatically registers profiling endpoints (`/debug/pprof/*`) on `http.DefaultServeMux`, leading to a CWE-200 vulnerability (exposure of sensitive system information).
🎯 **Impact:** If exposed, an attacker could access memory profiles, CPU profiles, and goroutine stack traces, potentially leaking sensitive application state or allowing for denial of service via CPU-intensive profiling requests.
🔧 **Fix:** Removed the `_ "net/http/pprof"` side-effect imports from both entrypoints. Documented the learning and prevention strategies in `.jules/sentinel.md`.
✅ **Verification:** Verify that `/debug/pprof` endpoints are no longer accessible on the default HTTP server. Run `go test ./...` and `go build ./...` to ensure no regressions. Verified using `gosec` that the G108 issue is resolved.

---
*PR created automatically by Jules for task [11683622912941966667](https://jules.google.com/task/11683622912941966667) started by @phbnf*