### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unauthenticated Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-03-24 - Unauthenticated Profiling Endpoint Exposure
+
+**Vulnerability:** The profiling endpoint `/debug/pprof` was inadvertently exposed due to `import _ "net/http/pprof"` in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
+**Learning:** Importing `net/http/pprof` automatically registers its handlers with the default `http.DefaultServeMux`. When these services expose the default mux (via `http.Handle` or `http.ListenAndServe(nil)` or implicitly exposing the global default mux due to how HTTP handlers were registered), the profiling endpoints become accessible to unauthenticated attackers, potentially leaking sensitive memory, CPU, or internal configuration data (CWE-200).
+**Prevention:** Avoid blanket `import _ "net/http/pprof"` in entrypoint packages, especially those serving public traffic. If profiling is needed, register pprof handlers explicitly to an internal, authenticated, or bound-to-localhost mux, or avoid importing it entirely if profiling is not strictly required.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The profiling endpoint `/debug/pprof` was inadvertently exposed due to `import _ "net/http/pprof"` in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. This automatically registers the pprof handlers to the global `http.DefaultServeMux`.
🎯 Impact: Unauthenticated attackers could access sensitive profiling data, potentially leaking memory contents, CPU details, or internal configuration data (CWE-200).
🔧 Fix: Removed the blanket `import _ "net/http/pprof"` from the public-facing entrypoint packages.
✅ Verification: Ran `grep -rnw . -e 'net/http/pprof'` to verify removal. Tests passed successfully. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7874459758965298287](https://jules.google.com/task/7874459758965298287) started by @phbnf*