### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-25 - [HIGH] Fix CWE-200 Profiling Endpoint Exposure
+**Vulnerability:** Profiling endpoint (`/debug/pprof`) is automatically exposed on public HTTP servers because the `net/http/pprof` package is imported in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
+**Learning:** Importing `net/http/pprof` for side effects registers its handlers to `http.DefaultServeMux`. If `http.DefaultServeMux` is inadvertently used or if the public server mux isn't strictly isolated from it, it exposes sensitive process internal state (CWE-200).
+**Prevention:** Do not import `_ "net/http/pprof"` in production binaries that expose public HTTP endpoints unless it is explicitly bound to a private, non-public listener.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Information Exposure (CWE-200). Profiling endpoints (`/debug/pprof/*`) were being automatically registered on the `http.DefaultServeMux` due to anonymous imports in the GCP and POSIX command binaries. If the public-facing HTTP server accidentally utilizes the default mux, this leaks sensitive process memory and state.
🎯 **Impact:** An attacker could dump process memory, inspect running goroutines, view command-line arguments, and potentially uncover sensitive information or keys loaded in memory.
🔧 **Fix:** Removed the `_ "net/http/pprof"` imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Documented this critical learning in `.jules/sentinel.md` to prevent future regressions.
✅ **Verification:** Ran `gosec` to ensure no `G108` issues remain and verified `go test ./...` passes without regressions.

---
*PR created automatically by Jules for task [13505194715845061286](https://jules.google.com/task/13505194715845061286) started by @phbnf*