### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-05-28 - [CWE-200] Prevent Profiling Endpoint Exposure in HTTP Servers
+
+**Vulnerability:** Profiling endpoints were inadvertently exposed globally on `http.DefaultServeMux` by importing `_ "net/http/pprof"` in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This exposed potentially sensitive memory and CPU profiling data (CWE-200) on endpoints that might be publicly accessible.
+
+**Learning:** The `net/http/pprof` package automatically registers handlers on `http.DefaultServeMux` upon initialization (`init()`). Any HTTP server that uses this mux or relies on default HTTP handling behavior without isolating its routing can inadvertently expose these debugging endpoints.
+
+**Prevention:** Never import `_ "net/http/pprof"` in production entry points unless access to `http.DefaultServeMux` is strictly restricted (e.g., bound only to `localhost` on an internal admin port). If profiling is necessary, explicitly register the handlers on a separate, securely bound `http.ServeMux`. Use OpenTelemetry or similar dedicated observability pipelines, as preferred by this project.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Importing `_ "net/http/pprof"` automatically registers `/debug/pprof/*` endpoints on the global `http.DefaultServeMux`. In web servers that might expose this mux or rely on default routing, this causes an unintentional exposure of sensitive profiling data, including memory dumps, CPU profiles, and internal execution paths (CWE-200).
🎯 **Impact**: An attacker accessing these endpoints could gain intimate knowledge of the application's internal state, memory layout, and potentially extract sensitive data from memory dumps. It also enables DoS attacks via CPU/memory exhaustion by repeatedly requesting expensive profiling operations.
🔧 **Fix**: Removed the blind imports of `_ "net/http/pprof"` from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. If profiling is needed, it must be explicitly configured on an isolated, internal-only `http.ServeMux`.
✅ **Verification**: Run `go build ./cmd/tesseract/...` to ensure compilation succeeds. Start the binary and verify that sending a GET request to `/debug/pprof/` returns a 404 Not Found instead of the profiling dashboard. Verified tests pass with `go test ./...`. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14704288952713293208](https://jules.google.com/task/14704288952713293208) started by @phbnf*