### PR TITLE
MaxBytesHandler

### DIFF
--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -81,7 +81,7 @@ var (
 
 	// Performance flags
 	httpDeadline                = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
-	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 1<<19, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
+	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 512<<10, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	inMemoryAntispamCacheSize   = flag.String("inmemory_antispam_cache_size", "256k", "Maximum number of entries to keep in the in-memory antispam cache. Unitless with SI metric prefixes, such as '256k'.")
 	checkpointInterval          = flag.Duration("checkpoint_interval", 1500*time.Millisecond, "Interval between publishing checkpoints when the log has grown")
 	checkpointRepublishInterval = flag.Duration("checkpoint_republish_interval", 30*time.Second, "Interval between republishing a checkpoint for a log which hasn't grown since the previous checkpoint was published")

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -81,6 +81,7 @@ var (
 
 	// Performance flags
 	httpDeadline                = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
+	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 1<<19, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	inMemoryAntispamCacheSize   = flag.String("inmemory_antispam_cache_size", "256k", "Maximum number of entries to keep in the in-memory antispam cache. Unitless with SI metric prefixes, such as '256k'.")
 	checkpointInterval          = flag.Duration("checkpoint_interval", 1500*time.Millisecond, "Interval between publishing checkpoints when the log has grown")
 	checkpointRepublishInterval = flag.Duration("checkpoint_republish_interval", 30*time.Second, "Interval between republishing a checkpoint for a log which hasn't grown since the previous checkpoint was published")
@@ -167,8 +168,9 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 
 	hOpts := tesseract.LogHandlerOpts{
-		NotBeforeRL: notBeforeRLFromFlags(),
-		DedupRL:     dedupRL,
+		NotBeforeRL:       notBeforeRLFromFlags(),
+		DedupRL:           dedupRL,
+		MaxCertChainBytes: *maxCertChainBytes,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorageFunc(awsCfg), *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
@@ -184,6 +186,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		Addr: *httpEndpoint,
 		// Set timeout for reading headers to avoid a slowloris attack.
 		ReadHeaderTimeout: 5 * time.Second,
+		MaxHeaderBytes:    1 << 13, // 8 KiB
 	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -186,7 +186,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		Addr: *httpEndpoint,
 		// Set timeout for reading headers to avoid a slowloris attack.
 		ReadHeaderTimeout: 5 * time.Second,
-		MaxHeaderBytes:    1 << 13, // 8 KiB
+		MaxHeaderBytes:    8 << 10, // 8 KiB
 	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -88,6 +88,7 @@ var (
 
 	// Performance flags
 	httpDeadline                = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
+	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 1<<19, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	inMemoryAntispamCacheSize   = flag.String("inmemory_antispam_cache_size", "256k", "Maximum number of entries to keep in the in-memory antispam cache. Unitless with SI metric prefixes, such as '256k'.")
 	checkpointInterval          = flag.Duration("checkpoint_interval", 1500*time.Millisecond, "Interval between publishing checkpoints when the log has grown")
 	checkpointRepublishInterval = flag.Duration("checkpoint_republish_interval", 30*time.Second, "Interval between republishing a checkpoint for a log which hasn't grown since the previous checkpoint was published")
@@ -201,8 +202,9 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 
 	hOpts := tesseract.LogHandlerOpts{
-		NotBeforeRL: notBeforeRLFromFlags(),
-		DedupRL:     dedupRL,
+		NotBeforeRL:       notBeforeRLFromFlags(),
+		DedupRL:           dedupRL,
+		MaxCertChainBytes: *maxCertChainBytes,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage(gcsClient, hc), *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
@@ -218,6 +220,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		Addr: *httpEndpoint,
 		// Set timeout for reading headers to avoid a slowloris attack.
 		ReadHeaderTimeout: 5 * time.Second,
+		MaxHeaderBytes:    1 << 13, // 8 KiB
 	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -88,7 +88,7 @@ var (
 
 	// Performance flags
 	httpDeadline                = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
-	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 1<<19, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
+	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 8<<16, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	inMemoryAntispamCacheSize   = flag.String("inmemory_antispam_cache_size", "256k", "Maximum number of entries to keep in the in-memory antispam cache. Unitless with SI metric prefixes, such as '256k'.")
 	checkpointInterval          = flag.Duration("checkpoint_interval", 1500*time.Millisecond, "Interval between publishing checkpoints when the log has grown")
 	checkpointRepublishInterval = flag.Duration("checkpoint_republish_interval", 30*time.Second, "Interval between republishing a checkpoint for a log which hasn't grown since the previous checkpoint was published")
@@ -220,7 +220,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		Addr: *httpEndpoint,
 		// Set timeout for reading headers to avoid a slowloris attack.
 		ReadHeaderTimeout: 5 * time.Second,
-		MaxHeaderBytes:    1 << 13, // 8 KiB
+		MaxHeaderBytes:    8 << 10, // 8 KiB
 	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -88,7 +88,7 @@ var (
 
 	// Performance flags
 	httpDeadline                = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
-	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 8<<16, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
+	maxCertChainBytes           = flag.Int64("max_cert_chain_bytes", 512<<10, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	inMemoryAntispamCacheSize   = flag.String("inmemory_antispam_cache_size", "256k", "Maximum number of entries to keep in the in-memory antispam cache. Unitless with SI metric prefixes, such as '256k'.")
 	checkpointInterval          = flag.Duration("checkpoint_interval", 1500*time.Millisecond, "Interval between publishing checkpoints when the log has grown")
 	checkpointRepublishInterval = flag.Duration("checkpoint_republish_interval", 30*time.Second, "Interval between republishing a checkpoint for a log which hasn't grown since the previous checkpoint was published")

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -69,7 +69,7 @@ var (
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
-	maxCertChainBytes        = flag.Int64("max_cert_chain_bytes", 1<<19, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
+	maxCertChainBytes        = flag.Int64("max_cert_chain_bytes", 8<<16, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints. This MUST match the log's submission prefix as per https://c2sp.org/static-ct-api.")
 	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on endpoints URL paths: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
@@ -163,7 +163,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		Addr: *httpEndpoint,
 		// Set timeout for reading headers to avoid a slowloris attack.
 		ReadHeaderTimeout: 5 * time.Second,
-		MaxHeaderBytes:    1 << 13, // 8 KiB
+		MaxHeaderBytes:    8 << 10, // 8 KiB
 	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -69,6 +69,7 @@ var (
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
+	maxCertChainBytes        = flag.Int64("max_cert_chain_bytes", 1<<19, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints. This MUST match the log's submission prefix as per https://c2sp.org/static-ct-api.")
 	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on endpoints URL paths: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
@@ -144,8 +145,9 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 
 	hOpts := tesseract.LogHandlerOpts{
-		NotBeforeRL: notBeforeRLFromFlags(),
-		DedupRL:     dedupRL,
+		NotBeforeRL:       notBeforeRLFromFlags(),
+		DedupRL:           dedupRL,
+		MaxCertChainBytes: *maxCertChainBytes,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
@@ -161,6 +163,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		Addr: *httpEndpoint,
 		// Set timeout for reading headers to avoid a slowloris attack.
 		ReadHeaderTimeout: 5 * time.Second,
+		MaxHeaderBytes:    1 << 13, // 8 KiB
 	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -69,7 +69,7 @@ var (
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
-	maxCertChainBytes        = flag.Int64("max_cert_chain_bytes", 8<<16, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
+	maxCertChainBytes        = flag.Int64("max_cert_chain_bytes", 512<<10, "Maximum size of certificate chain in bytes for add-chain and add-pre-chain endpoints (default: 512 KiB)")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints. This MUST match the log's submission prefix as per https://c2sp.org/static-ct-api.")
 	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on endpoints URL paths: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")

--- a/ctlog.go
+++ b/ctlog.go
@@ -215,8 +215,9 @@ type NotBeforeRL struct {
 }
 
 type LogHandlerOpts struct {
-	NotBeforeRL *NotBeforeRL
-	DedupRL     float64
+	NotBeforeRL       *NotBeforeRL
+	DedupRL           float64
+	MaxCertChainBytes int64
 }
 
 // NewLogHandler creates a Tessera based CT log plugged into HTTP handlers.
@@ -256,7 +257,7 @@ func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg
 	mux := http.NewServeMux()
 	// Register handlers for all the configured logs.
 	for path, handler := range handlers {
-		mux.Handle(path, handler)
+		mux.Handle(path, http.MaxBytesHandler(handler, opts.MaxCertChainBytes))
 	}
 
 	// Health checking endpoint.

--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -392,6 +392,10 @@ func parseBodyAsJSONChain(r *http.Request) (rfc6962.AddChainRequest, error) {
 	defer returnBuffer(buf)
 
 	if _, err := buf.ReadFrom(r.Body); err != nil {
+		if mbe, ok := err.(*http.MaxBytesError); ok {
+			klog.V(1).Infof("Request body exceeds %d-byte limit", mbe.Limit)
+			return rfc6962.AddChainRequest{}, fmt.Errorf("certificate chain exceeds %d-byte limit: %w", mbe.Limit, err)
+		}
 		klog.V(1).Infof("Failed to read request body: %v", err)
 		return rfc6962.AddChainRequest{}, err
 	}
@@ -427,6 +431,10 @@ func addChainInternal(ctx context.Context, opts *HandlerOptions, log *log, w htt
 	// Check the contents of the request and convert to slice of certificates.
 	addChainReq, err := parseBodyAsJSONChain(r)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return http.StatusRequestEntityTooLarge, nil, fmt.Errorf("%s: %v", log.origin, err)
+		}
 		return http.StatusBadRequest, nil, fmt.Errorf("%s: failed to parse add-chain body: %s", log.origin, err)
 	}
 	// Log the DERs now because they might not parse as valid X.509.

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -66,8 +66,8 @@ var (
 	prefix = "/" + origin
 
 	// POSIX subdirectory
-	logDir = "log"
-	maxCertChainSize = int64(1<<19) // 512 KiB
+	logDir           = "log"
+	maxCertChainSize = int64(8 << 16) // 512 KiB
 )
 
 func hOpts() *HandlerOptions {
@@ -1099,4 +1099,3 @@ func BenchmarkParseBodyAsJSONChain(b *testing.B) {
 		}
 	}
 }
-

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -66,6 +67,7 @@ var (
 
 	// POSIX subdirectory
 	logDir = "log"
+	maxCertChainSize = int64(1<<19) // 512 KiB
 )
 
 func hOpts() *HandlerOptions {
@@ -279,14 +281,15 @@ func TestGetHandlersRejectPost(t *testing.T) {
 func TestPostHandlersFailure(t *testing.T) {
 	var tests = []struct {
 		descr string
-		body  io.Reader
+		body  string
 		want  int
 	}{
-		{"nil", nil, http.StatusBadRequest},
-		{"''", strings.NewReader(""), http.StatusBadRequest},
-		{"malformed-json", strings.NewReader("{ !$%^& not valid json "), http.StatusBadRequest},
-		{"empty-chain", strings.NewReader(`{ "chain": [] }`), http.StatusBadRequest},
-		{"wrong-chain", strings.NewReader(`{ "chain": [ "test" ] }`), http.StatusBadRequest},
+		{"nil", "", http.StatusBadRequest},
+		{"''", "", http.StatusBadRequest},
+		{"malformed-json", "{ !$%^& not valid json ", http.StatusBadRequest},
+		{"empty-chain", `{ "chain": [] }`, http.StatusBadRequest},
+		{"wrong-chain", `{ "chain": [ "test" ] }`, http.StatusBadRequest},
+		{"too-large-body", fmt.Sprintf(`{ "chain": [ "%s" ] }`, strings.Repeat("A", int(maxCertChainSize+1))), http.StatusRequestEntityTooLarge},
 	}
 
 	log, _ := setupTestLog(t)
@@ -294,10 +297,14 @@ func TestPostHandlersFailure(t *testing.T) {
 
 	for path, handler := range postHandlers(t, handlers) {
 		t.Run(path, func(t *testing.T) {
-			s := httptest.NewServer(handler)
+			s := httptest.NewServer(http.MaxBytesHandler(handler, maxCertChainSize))
 
 			for _, test := range tests {
-				resp, err := http.Post(s.URL+path, "application/json", test.body)
+				var bodyReader io.Reader
+				if test.body != "" {
+					bodyReader = strings.NewReader(test.body)
+				}
+				resp, err := http.Post(s.URL+path, "application/json", bodyReader)
 				if err != nil {
 					t.Errorf("http.Post(%s,%s)=(_,%q); want (_,nil)", path, test.descr, err)
 					continue

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -67,7 +67,7 @@ var (
 
 	// POSIX subdirectory
 	logDir           = "log"
-	maxCertChainSize = int64(8 << 16) // 512 KiB
+	maxCertChainSize = int64(512 << 10) // 512 KiB
 )
 
 func hOpts() *HandlerOptions {


### PR DESCRIPTION
- **re-enable gargabe collection (#789)**
- **extra flags (#791)**
- **Bump the all-deps group with 10 updates (#787)**
- **golangci-lint v2 config (#794)**
- **cert per service (#793)**
- **rename databases (#795)**
- **typo (#796)**
- **use better ssl resource names (#798)**
- **Bump google.golang.org/grpc from 1.79.2 to 1.79.3 (#799)**
- **suffix SSL cert names with a random ID (#800)**
- **unpprof (#801)**
- **gcs_use_grpc defaults to true (#802)**
- **support multiple remote endpoints (#797)**
- **Bump the all-deps group across 1 directory with 4 updates (#804)**
- **Bump google.golang.org/api from 0.271.0 to 0.272.0 in the all-deps group (#803)**
- **Bump Tessera to 55be0bb9dffada3e6fdba5fd20962f0e4413bf88 (#807)**
- **expvar (#806)**
- **Add experimental POSIX migrate tool (#805)**
- **rate limit old submission by default, fix extKeyUsage description (#809)**
- **Refresh README (#810)**
- **MaxBytesHandler**
