### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposed pprof endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-27 - Exposed Profiling Endpoint
+**Vulnerability:** The standard library `net/http/pprof` automatically registers profiling endpoints to `http.DefaultServeMux`, exposing sensitive system information.
+**Learning:** In the POSIX server entrypoint, this package was anonymously imported (`_ "net/http/pprof"`), leading to CWE-200.
+**Prevention:** Ensure that `net/http/pprof` is not imported, especially on public-facing custom multiplexers.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Go standard library `net/http/pprof` was anonymously imported in the POSIX server entrypoint (`cmd/tesseract/posix/main.go`). This automatically registers profiling endpoints (`/debug/pprof/*`) to `http.DefaultServeMux`, which can expose sensitive system information (memory, CPU, and goroutine profiles) if the default mux is exposed.
🎯 Impact: Malicious actors could access the profiling endpoints to gather sensitive system information, leading to an information exposure vulnerability (CWE-200).
🔧 Fix: Removed the `_ "net/http/pprof"` import from `cmd/tesseract/posix/main.go`.
✅ Verification: Verified the file change and ran all tests (`go test ./...`) to ensure no functionality is broken. Also recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5804501225501794932](https://jules.google.com/task/5804501225501794932) started by @phbnf*