### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiler Endpoint Exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-28 - [Profiler Exposed]
+**Vulnerability:** Automatically exposed `net/http/pprof` endpoints.
+**Learning:** `_ "net/http/pprof"` was anonymously imported in `cmd/tesseract/posix/main.go`, inadvertently exposing profiling endpoints via `http.DefaultServeMux`, which introduces a CWE-200 vulnerability when the mux is exposed.
+**Prevention:** Remove `_ "net/http/pprof"` imports from public-facing binaries and configure pprof to use a dedicated, internal HTTP server if profiling is required.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The anonymous import of `_ "net/http/pprof"` automatically attaches debugging handlers to `http.DefaultServeMux`. If `http.ListenAndServe` or `http.Server` handles requests using this default mux, sensitive profiling information is exposed.
🎯 Impact: Attackers could access `/debug/pprof/*` endpoints to download CPU profiles, heap profiles, and execution traces, potentially leaking application internals, memory structures, and sensitive data.
🔧 Fix: Removed the `net/http/pprof` import from the POSIX entry point.
✅ Verification: Ran `gosec` which now reports 0 issues related to G108 (profiling endpoint exposure). Build succeeds and journal updated.

---
*PR created automatically by Jules for task [12207651078038881412](https://jules.google.com/task/12207651078038881412) started by @phbnf*