### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof profiling endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Unintentional pprof Exposure
+**Vulnerability:** Profiling endpoints were automatically exposed on `/debug/pprof` by importing `_ "net/http/pprof"`.
+**Learning:** Importing `net/http/pprof` registers its handlers on the global `http.DefaultServeMux`. If an application exposes this mux without authentication, it inadvertently exposes sensitive profiling data.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` in production-facing applications or explicitly restrict access to profiling endpoints.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `net/http/pprof` automatically registers profiling endpoints (`/debug/pprof/*`) on `http.DefaultServeMux`. If an application uses this default mux (e.g. `http.ListenAndServe(addr, nil)` or passing `http.DefaultServeMux`), it inadvertently exposes sensitive runtime profiling data to the public without authentication.
🎯 Impact: Unauthorized users could access debugging and profiling information (CPU, memory, goroutines) that provides insights into application logic, potential vulnerabilities, and runtime state, causing a CWE-200.
🔧 Fix: Removed the anonymous `_ "net/http/pprof"` import from `cmd/tesseract/posix/main.go`.
✅ Verification: Ensure the `/debug/pprof` endpoints are no longer accessible without returning a 404 (if unhandled).

---
*PR created automatically by Jules for task [13353761269623209579](https://jules.google.com/task/13353761269623209579) started by @phbnf*