### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposed pprof and expvar endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-18 - Fix exposed pprof and expvar endpoints (CWE-200)
+**Vulnerability:** Blank imports (`_ "net/http/pprof"` and `_ "expvar"`) in `cmd/tesseract/posix/main.go` implicitly registered profiling and metric endpoints on the global `http.DefaultServeMux`, inadvertently exposing them when serving the public-facing API.
+**Learning:** Even if a custom ServeMux is not explicitly exposing debug paths, importing packages like `net/http/pprof` or `expvar` automatically registers their handlers to the default mux. If the server is bound without explicitly avoiding `DefaultServeMux` or if there's confusion about which mux is used, this creates a CWE-200 (Information Exposure) vulnerability.
+**Prevention:** Avoid blank imports of `net/http/pprof` and `expvar` in production binaries, especially when building internet-facing services. Alternatively, register these handlers to an internal, authenticated, or port-isolated ServeMux.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Information Exposure (CWE-200). Blank imports of `net/http/pprof` and `expvar` in the `posix` binary automatically registered debugging, telemetry, and profiling endpoints onto the global `http.DefaultServeMux`. If an application does not tightly control which mux is exposed, or inadvertently exposes the default mux, unauthenticated attackers can access sensitive internal application state and profiling endpoints.
🎯 Impact: Attackers could retrieve sensitive heap details, command line arguments, goroutine dumps, and other internal metrics, which could be used to piece together attacks, leak sensitive memory, or execute DoS vectors against the profiling paths.
🔧 Fix: Removed the explicit blank imports `_ "net/http/pprof"` and `_ "expvar"` from `cmd/tesseract/posix/main.go`. Documented the learning in `.jules/sentinel.md`.
✅ Verification: Ran `go build ./cmd/tesseract/posix/` and verified that running the binary does not expose `/debug/pprof/` or `/debug/vars` anymore. Also ensured no regressions by successfully running all repository tests via `go test ./...`.

---
*PR created automatically by Jules for task [10855442078108523348](https://jules.google.com/task/10855442078108523348) started by @phbnf*