### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling endpoint exposure

### DIFF
--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Exposure of debug and profiling endpoints (`/debug/pprof` and `/debug/vars`) on the default `http.DefaultServeMux` due to blank imports of `net/http/pprof` and `expvar`.
🎯 Impact: Attackers could access internal memory profiles, execution traces, and application state variables (like BadgerDB metrics), leading to sensitive information disclosure (CWE-200) or potential Denial of Service.
🔧 Fix: Removed the anonymous imports from `cmd/tesseract/posix/main.go`. This prevents the endpoints from being registered automatically on the default multiplexer.
✅ Verification: `gosec -fmt=text ./cmd/tesseract/posix/...` no longer reports G108 vulnerabilities, and `go test ./...` passes.

---
*PR created automatically by Jules for task [8855312747730915888](https://jules.google.com/task/8855312747730915888) started by @phbnf*