### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - CWE-200 Profiling Endpoint Exposure
+**Vulnerability:** Import of `_ "net/http/pprof"` and `_ "expvar"` in binary entry points registers debugging endpoints (`/debug/pprof/*` and `/debug/vars`) on the `http.DefaultServeMux`.
+**Learning:** This exposes sensitive application internals (metrics, memory profiles, CPU profiles) that an attacker could use to glean information or conduct denial of service attacks.
+**Prevention:** Avoid registering global side-effect imports like `_ "net/http/pprof"` and `_ "expvar"` in binaries that start HTTP servers. Instead, attach these endpoints explicitly to a dedicated, restricted-access multiplexer if profiling is necessary.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Information exposure via default HTTP server multiplexer endpoints (pprof and expvar).
🎯 Impact: An attacker could access internal debugging and metrics information, aiding in exploiting other vulnerabilities.
🔧 Fix: Removed `net/http/pprof` and `expvar` imports from the POSIX entry point.
✅ Verification: Verified code compiles and tests pass.

---
*PR created automatically by Jules for task [7084939976008194996](https://jules.google.com/task/7084939976008194996) started by @phbnf*