### PR TITLE
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Unintentional Exposure of Profiling Endpoint
+**Vulnerability:** `net/http/pprof` was anonymously imported (`_ "net/http/pprof"`) in `cmd/tesseract/posix/main.go`, which automatically registers its handler with the default `http.ServeMux`. Since `posix/main.go` uses `http.Handle("/", logHandler)` without allocating a custom router, it exposes standard pprof endpoints to the public interface.
+**Learning:** Anonymous import of `net/http/pprof` or `expvar` alongside the use of the default `ServeMux` (often used in simple setups) unintentionally exposes sensitive internal application state and profiling functionality to unauthenticated external users.
+**Prevention:** Avoid importing `net/http/pprof` or `expvar` in production entry points unless they are explicitly bound to an internal-only port or protected by authentication. Use OpenTelemetry for performance metrics instead.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure

**Severity:** HIGH (CWE-200 Information Exposure)
**Vulnerability:** `net/http/pprof` and `expvar` were anonymously imported (`_ "net/http/pprof"`) in `cmd/tesseract/posix/main.go`. This automatically registers profiling and metrics handlers on `http.DefaultServeMux`. Since the application routes traffic via `http.Handle("/", logHandler)` on the default Mux, these endpoints were publicly accessible.
**Impact:** Unauthenticated external users could access internal application state, memory profiles, CPU profiles, and BadgerDB metrics.
**Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go`. This unregisters the handlers from the default Mux.
**Verification:** Running `gosec ./cmd/tesseract/posix/...` no longer reports the G108 finding. The application compiles and tests pass.
**Learnings:** A new journal entry was added to `.jules/sentinel.md` noting the risks of anonymous profiling imports in production entry points using `http.DefaultServeMux`.

---
*PR created automatically by Jules for task [620034250946520132](https://jules.google.com/task/620034250946520132) started by @phbnf*