### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Information Exposure in POSIX server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Do not expose profiling endpoints automatically
+
+**Vulnerability:** Information Exposure (CWE-200) / Profiling Endpoint Exposure via `net/http/pprof` and `expvar`.
+**Learning:** Importing `net/http/pprof` and `expvar` automatically registers handlers on `http.DefaultServeMux`. If an HTTP server uses `http.DefaultServeMux` (or if it gets bound publicly in any way), profiling endpoints (like `/debug/pprof/*` and `/debug/vars`) become accessible to anyone, leaking sensitive application state, internal metrics, and potentially allowing denial-of-service or further reconnaissance.
+**Prevention:** In public-facing applications or entry points (like `cmd/tesseract/*/main.go`), do not import `_ "net/http/pprof"` or `_ "expvar"`. If profiling is required, it must be bound to a separate, internal-only interface or strictly authenticated and authorized on a specific multiplexer instead of the default global mux.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Information Exposure (CWE-200) via automatically exposed profiling endpoints (`net/http/pprof` and `expvar`) on the default `http.ServeMux`.
🎯 **Impact:** Exposes internal metrics, application state, and profiling data (such as command-line arguments and heap memory analysis) to any client that accesses the HTTP endpoint, leading to potential reconnaissance or denial of service risks.
🔧 **Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from the POSIX entry point (`cmd/tesseract/posix/main.go`). Added the learning to the Sentinel journal `.jules/sentinel.md`.
✅ **Verification:** Verified via `gosec` that rule G108 is no longer firing for this file. Checked via `go test ./...` and `go build ./...` that it compiles and passes basic checks.

---
*PR created automatically by Jules for task [16242183125093802809](https://jules.google.com/task/16242183125093802809) started by @phbnf*