### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 exposed profiling endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-05 - Remove exposed profiling endpoints
+**Vulnerability:** Profiling (`net/http/pprof`) and metrics (`expvar`) endpoints were exposed via anonymous imports. This can lead to a CWE-200 vulnerability, leaking sensitive application data.
+**Learning:** Anonymous imports of `net/http/pprof` or `expvar` automatically register HTTP handlers on the default serve mux `http.DefaultServeMux`. If `http.ListenAndServe` or `http.Server.ListenAndServe` uses the default serve mux without overriding handlers, the debug endpoints become publicly available.
+**Prevention:** Avoid blank imports of `net/http/pprof` and `expvar` in binaries meant for production that expose an HTTP server. Only expose diagnostic endpoints internally or over authenticated interfaces.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removed exposed pprof and expvar endpoints from POSIX entrypoint to mitigate CWE-200 data exposure. Recorded security learnings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11349350786098282522](https://jules.google.com/task/11349350786098282522) started by @phbnf*