### PR TITLE
🛡️ Sentinel: [HIGH] Fix pprof endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-08 - Remove pprof and expvar from public endpoints
+**Vulnerability:** Publicly accessible profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints due to importing `_ "net/http/pprof"` and `_ "expvar"`.
+**Learning:** Importing these packages registers endpoints on `http.DefaultServeMux`. If a public server falls back to this default mux (e.g., via `http.Handle("/", handler)` without specifying a custom mux), these endpoints are exposed, creating a CWE-200 vulnerability.
+**Prevention:** Avoid using `_ "net/http/pprof"` and `_ "expvar"` in production binaries. Explicitly map these to a private/internal server if needed, or use safe observability libraries like OpenTelemetry instead.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Publicly accessible profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints.
- 🎯 Impact: Exposure of internal metrics and performance profiles which can aid attackers in reconnaissance and exploiting the system.
- 🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go`.
- ✅ Verification: Ensured the endpoints are no longer registered on `http.DefaultServeMux`.

---
*PR created automatically by Jules for task [7334091255764139512](https://jules.google.com/task/7334091255764139512) started by @phbnf*