### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-09 - Fix CWE-200 profiling endpoint exposure on posix backend
+**Vulnerability:** The POSIX cloud personality entry point (`cmd/tesseract/posix/main.go`) included blank imports for `net/http/pprof` and `expvar`.
+**Learning:** Including these blank imports automatically registers profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints on the global `http.DefaultServeMux`. If `http.DefaultServeMux` is used or exposed in a public-facing application, this leaks sensitive internal state and performance data (CWE-200).
+**Prevention:** Avoid blank imports of `net/http/pprof` and `expvar` in production binaries. Use OpenTelemetry (otel) for observability, as done in the AWS and GCP handlers, and deliberately avoid exposing these default endpoints.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removes the blank imports of `net/http/pprof` and `expvar` from the POSIX entry point (`cmd/tesseract/posix/main.go`).

🚨 **Severity:** HIGH
💡 **Vulnerability:** The `net/http/pprof` and `expvar` packages automatically register endpoints (`/debug/pprof/*` and `/debug/vars`) on the global `http.DefaultServeMux` upon initialization via blank import.
🎯 **Impact:** If `http.DefaultServeMux` is used or inadvertently exposed, unauthenticated users can access profiling and metrics data, revealing sensitive application state and memory information (CWE-200).
🔧 **Fix:** Removed the blank imports from `cmd/tesseract/posix/main.go`.
✅ **Verification:** Verified that the imports are no longer present in the file, built the binary, and ran tests. Recorded the security learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11000730812626775703](https://jules.google.com/task/11000730812626775703) started by @phbnf*