### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 pprof exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-10 - [Fix CWE-200 pprof exposure]
+**Vulnerability:** The HTTP server entry point `cmd/tesseract/posix/main.go` inadvertently exposed profiling and metrics endpoints (`/debug/pprof/*`) on `http.DefaultServeMux` because of a wildcard import `_ "net/http/pprof"`. This can lead to a CWE-200 vulnerability.
+**Learning:** The entry points in `cmd/tesseract/*/main.go` must not import `_ "net/http/pprof"` or `_ "expvar"` to avoid inadvertently exposing these endpoints on `http.DefaultServeMux` to the internet, potentially leaking sensitive memory, cpu profile and environment details.
+**Prevention:** Do not import `_ "net/http/pprof"` or `_ "expvar"` globally. If profiling is needed, it should be bound to a separate internal admin port rather than the main `http.ServeMux` or `http.DefaultServeMux`.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🛡️ Sentinel has identified and fixed a HIGH severity security issue.

🚨 **Severity:** HIGH
💡 **Vulnerability:** The HTTP server entry point `cmd/tesseract/posix/main.go` inadvertently exposed profiling and metrics endpoints (`/debug/pprof/*`) on `http.DefaultServeMux` because of a wildcard import `_ "net/http/pprof"`. This can lead to a CWE-200 vulnerability.
🎯 **Impact:** If exposed to the internet, attackers could access memory profiles, stack traces, and environment details, potentially leaking sensitive information and aiding further attacks.
🔧 **Fix:** Removed the `_ "net/http/pprof"` import from `cmd/tesseract/posix/main.go`.
✅ **Verification:** Verified via `gosec` that the G108 rule no longer flags this file. Rebuilt the binary to ensure no compilation errors.

---
*PR created automatically by Jules for task [7250716850868496007](https://jules.google.com/task/7250716850868496007) started by @phbnf*