### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling Endpoint Exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-04-11 - Prevent Profiling and Metrics Endpoint Exposure (CWE-200)
+**Vulnerability:** Profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) were inadvertently exposed on `http.DefaultServeMux` because `_ "net/http/pprof"` and `_ "expvar"` were imported in the POSIX cloud personality entry point (`cmd/tesseract/posix/main.go`). This allowed potential attackers to access internal metrics and stack traces, exposing sensitive application state.
+**Learning:** Anonymous imports of `net/http/pprof` or `expvar` automatically register HTTP handlers on the default multiplexer (`http.DefaultServeMux`). If a public-facing HTTP server uses this multiplexer or falls back to it, these sensitive debug endpoints are exposed to the public internet, violating CWE-200.
+**Prevention:** Do not import `_ "net/http/pprof"` or `_ "expvar"` in entry points (`cmd/tesseract/*/main.go`) or any package used in production binaries. If profiling or metrics are required, explicitly bind their handlers to a separate internal-only or protected multiplexer, or use secure observability solutions like OpenTelemetry (which is already configured).

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,8 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unintentional exposure of internal debugging and profiling endpoints (`/debug/pprof/*`, `/debug/vars`) due to blank imports of `net/http/pprof` and `expvar` registering handlers on the `http.DefaultServeMux`.
🎯 **Impact:** Potential attackers could access internal metrics, runtime profiling data, and stack traces, leading to significant information disclosure (CWE-200) and increased attack surface.
🔧 **Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from the `cmd/tesseract/posix/main.go` entry point. Documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Verified that building `cmd/tesseract/posix` succeeds and the `gosec` static analysis tool no longer reports the `G108` rule violation for this file. All unit tests continue to pass.

---
*PR created automatically by Jules for task [3609889544664896843](https://jules.google.com/task/3609889544664896843) started by @phbnf*