### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of profiling endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Remove inadvertent exposure of profiling endpoints
+**Vulnerability:** The `cmd/tesseract/posix/main.go` entrypoint imported `net/http/pprof` and `expvar`, which automatically bound profiling endpoints (`/debug/pprof/*` and `/debug/vars`) to `http.DefaultServeMux`.
+**Learning:** In Go, importing `net/http/pprof` or `expvar` for side-effects registers HTTP handlers on the default ServeMux. If this Mux is used to serve public traffic (or if the application doesn't explicitly restrict access), sensitive internal metrics and profiling data can be exposed to attackers (CWE-200).
+**Prevention:** Avoid blank imports of `net/http/pprof` and `expvar` in production binaries unless they are explicitly bound to a secure, internal-only administrative port. Use custom `http.ServeMux` instances instead of `http.DefaultServeMux` to minimize accidental handler exposure.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,7 +43,6 @@ import (
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removed `net/http/pprof` and `expvar` imports from the posix entrypoint. These inadvertently bind to `http.DefaultServeMux` and expose profiling endpoints like `/debug/pprof` and `/debug/vars` publicly, leading to potential information disclosure (CWE-200).

---
*PR created automatically by Jules for task [433047686288003020](https://jules.google.com/task/433047686288003020) started by @phbnf*