### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar profiling endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-18 - Fix exposure of pprof and expvar profiling endpoints
+**Vulnerability:** The POSIX cloud personality binary implicitly exposed profiling endpoints (`/debug/pprof/*`) and metrics endpoints (`/debug/vars`) via `http.DefaultServeMux` due to blank imports of `net/http/pprof` and `expvar`. This exposed server internals and sensitive profiling data to unauthorized actors (CWE-200).
+**Learning:** Adding `net/http/pprof` or `expvar` imports automatically registers debug routes on `http.DefaultServeMux`. If `http.Server` starts without explicit custom multiplexers or with open bindings, these become publicly accessible. The POSIX handler was attaching to the default server mux exposing these.
+**Prevention:** Avoid blank importing `net/http/pprof` and `expvar` in production entry points unless they are isolated to a separate internal listener or tightly controlled administrative endpoint. OpenTelemetry is generally preferred and already used here.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The POSIX cloud personality binary implicitly exposed profiling endpoints (`/debug/pprof/*`) and metrics endpoints (`/debug/vars`) via `http.DefaultServeMux` due to blank imports of `net/http/pprof` and `expvar`.
🎯 **Impact**: Exposed server internals and sensitive profiling data to unauthorized actors over the network, leading to an Information Exposure vulnerability (CWE-200).
🔧 **Fix**: Removed the `net/http/pprof` and `expvar` blank imports from `cmd/tesseract/posix/main.go`. OpenTelemetry handles metrics securely.
✅ **Verification**: Run `go build ./cmd/tesseract/posix` to ensure it builds correctly, and `go test ./...` to verify no regressions were introduced.

Includes an update to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [2760047455170191180](https://jules.google.com/task/2760047455170191180) started by @phbnf*