### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profile Information Leakage in Posix Personality

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-19 - Mitigate Profile Information Leakage in Posix Personality
+**Vulnerability:** The posix cloud personality entry point `cmd/tesseract/posix/main.go` inadvertently exposed the profiling and metric endpoint `/debug/pprof/*` because `net/http/pprof` was imported to leverage the initialization side effect. This exposes sensitive details of the running processes, allowing profiling info leakage, a CWE-200 vulnerability.
+**Learning:** `net/http/pprof` registers the profiling handlers directly on the `http.DefaultServeMux` via its `init` function. When using `http.Handle` to register on `DefaultServeMux`, the profiling endpoints are also silently exposed.
+**Prevention:** Do not import `net/http/pprof` in cloud personality or custom entry points using `http.DefaultServeMux`. If profiling is required, mount the handlers selectively using a custom `http.ServeMux` and ensure they are on an internal or protected port, separate from the public internet API port.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Profile Information Leakage in Posix Personality

🚨 Severity: HIGH (CWE-200)
💡 Vulnerability: The `cmd/tesseract/posix/main.go` entry point inadvertently imported `_ "net/http/pprof"`. This registers profiling routes (`/debug/pprof/*`) to `http.DefaultServeMux`. Since the application starts an HTTP server using `http.DefaultServeMux`, the profiler gets exposed to the public API endpoint.
🎯 Impact: Attackers can access detailed runtime profiling, memory, and routing information, facilitating reconnaissance and potentially exposing sensitive application state or secrets.
🔧 Fix: Removed the `_ "net/http/pprof"` import from the posix entry point.
✅ Verification: `grep -rn '"net/http/pprof"' cmd/` returns no results, and `go test ./...` passes.

---
*PR created automatically by Jules for task [9792817311946503329](https://jules.google.com/task/9792817311946503329) started by @phbnf*