### PR TITLE
🛡️ Sentinel: [HIGH] Fix net/http/pprof endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-20 - Exposing Profiling Endpoints via `net/http/pprof`
+**Vulnerability:** The POSIX cloud personality binary (`cmd/tesseract/posix/main.go`) incorrectly imported `_ "net/http/pprof"` and `_ "expvar"`, exposing profiling and debugging endpoints (like `/debug/pprof/*` and `/debug/vars`) via `http.DefaultServeMux`, leading to potential CWE-200 (Information Exposure) vulnerability.
+**Learning:** Development tools and metric systems can unintentionally bind endpoints to the global `http.DefaultServeMux` upon import, causing them to be exposed on public-facing servers.
+**Prevention:** Avoid blindly importing packages that rely on side-effects to configure global state. Specifically, refrain from using `_ "net/http/pprof"` in public services; use dedicated metric tools like OpenTelemetry which are safe from side-channel endpoint exposure.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The POSIX cloud personality binary (`cmd/tesseract/posix/main.go`) incorrectly imported `_ "net/http/pprof"` and `_ "expvar"`, exposing profiling and debugging endpoints (like `/debug/pprof/*` and `/debug/vars`) via `http.DefaultServeMux`.
🎯 Impact: Attackers or unauthenticated users could access sensitive profiling data, memory statistics, and internal server metrics, leading to a CWE-200 Information Exposure vulnerability.
🔧 Fix: Removed the anonymous imports for `net/http/pprof` and `expvar` from `cmd/tesseract/posix/main.go`.
✅ Verification: Tested locally by verifying that the application compiles without errors and passes all test suites (`go test ./...`). A `grep` check confirms the imports are no longer present.

---
*PR created automatically by Jules for task [261947042708833185](https://jules.google.com/task/261947042708833185) started by @phbnf*