### PR TITLE
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Profiling endpoint exposure (CWE-200)
+**Vulnerability:** The public-facing posix server imported `_ "net/http/pprof"` and `_ "expvar"`.
+**Learning:** Importing these packages automatically registers handlers on the default `http.DefaultServeMux`. If `http.DefaultServeMux` is used or exposed (e.g. implicitly, or if a custom server doesn't explicitly restrict routes), this exposes sensitive profiling data and internal metrics on endpoints like `/debug/pprof/*` and `/debug/vars`, leading to information disclosure.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` or `expvar` in binaries intended for production deployment without explicitly configuring a dedicated, secured (e.g. internal only) serve mux for debugging and profiling.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The public-facing posix server imported `_ "net/http/pprof"` and `_ "expvar"`. This automatically registers handlers on the default `http.DefaultServeMux`, exposing sensitive profiling data and internal metrics on endpoints like `/debug/pprof/*` and `/debug/vars`, leading to information disclosure (CWE-200).
🎯 **Impact:** An attacker could potentially gain sensitive information about the application's performance, memory, and runtime, helping them construct further attacks.
🔧 **Fix:** Removed the anonymous imports from `cmd/tesseract/posix/main.go`. Documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Verified by running tests and confirming the `gosec` G108 finding is resolved.

---
*PR created automatically by Jules for task [2387568225435165786](https://jules.google.com/task/2387568225435165786) started by @phbnf*