### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Remove auto-exposed pprof and expvar endpoints
+**Vulnerability:** pprof profiling endpoints and expvar metrics were automatically exposed on `/debug/pprof` and `/debug/vars` globally because the `cmd/tesseract/posix/main.go` entrypoint anonymously imported `net/http/pprof` and `expvar` (CWE-200).
+**Learning:** Anonymous imports of these packages automatically bind their handlers to `http.DefaultServeMux`. If the application uses the default mux, these endpoints are exposed to the internet.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar`. If profiling or metrics are needed, explicitly bind them to a separate internal server or use a framework like OpenTelemetry.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `cmd/tesseract/posix/main.go` entry point imported `net/http/pprof` and `expvar` anonymously. In Go, this automatically registers profiling and debugging endpoints (`/debug/pprof/*` and `/debug/vars`) to the `http.DefaultServeMux`, which is exposed if the default mux is used without restrictions. This allows unauthenticated remote attackers to access sensitive memory, CPU profiles, and runtime metrics (CWE-200).
🎯 Impact: Attackers could gain insights into the application's internal state, potentially extracting sensitive information or discovering further vulnerabilities by analyzing memory dumps and runtime metrics.
🔧 Fix: Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go`.
✅ Verification: Ensure the endpoints `/debug/pprof/` and `/debug/vars` are no longer accessible when running the `posix` binary, and verify that `net/http/pprof` and `expvar` are not imported in `cmd/tesseract/posix/main.go`.

---
*PR created automatically by Jules for task [8316699702567792593](https://jules.google.com/task/8316699702567792593) started by @phbnf*