### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Information Exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-24 - [CRITICAL] Fix Information Exposure (CWE-200) via pprof and expvar
+**Vulnerability:** The `cmd/tesseract/posix/main.go` file imported `net/http/pprof` and `expvar`. This exposed the `/debug/pprof/*` and `/debug/vars` endpoints on the global `http.DefaultServeMux`. These endpoints can leak sensitive internal information, causing a CWE-200 vulnerability.
+**Learning:** Importing profiling and debugging endpoints globally (`net/http/pprof`, `expvar`) on production binaries is a critical security risk because they bind directly to the default multiplexer, potentially exposing sensitive application and memory data publicly.
+**Prevention:** Never import `_ "net/http/pprof"` or `_ "expvar"` in production binaries directly. Explicitly configure monitoring and metrics to be bound to restricted internal-only administration ports instead of the public-facing HTTP multiplexer.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `cmd/tesseract/posix/main.go` file imported `net/http/pprof` and `expvar`. This exposed the `/debug/pprof/*` and `/debug/vars` endpoints on the global `http.DefaultServeMux`. These endpoints can leak sensitive internal application state, memory profiling data, and performance metrics, causing a CWE-200 (Information Exposure) vulnerability.
🎯 Impact: If the HTTP server inadvertently exposes the default mux to the public internet, unauthenticated attackers could access detailed internal server metrics, aiding in denial of service attacks, memory inspection, or discovering further vulnerabilities.
🔧 Fix: Removed the side-effect imports `_ "net/http/pprof"` and `_ "expvar"` from the production binary.
✅ Verification: Ran `go build ./cmd/tesseract/posix` and `go test ./... -short` to confirm the application builds cleanly and tests pass. Verified the endpoints are no longer imported. Added a learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13166644788698892684](https://jules.google.com/task/13166644788698892684) started by @phbnf*