### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-200 Exposure of Profiling Endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-26 - Fix CWE-200 Exposure of Profiling Endpoints
+**Vulnerability:** The application was exposing `net/http/pprof` and `expvar` endpoints (like `/debug/pprof/*` and `/debug/vars`) on the `http.DefaultServeMux` because these packages were imported via `_` in `cmd/tesseract/posix/main.go`. This exposes internal application profiling and memory metrics to the public, which is a CWE-200 vulnerability.
+**Learning:** In Go, importing `net/http/pprof` or `expvar` automatically registers handlers on `http.DefaultServeMux`. If an application uses this default mux for public HTTP traffic, these internal diagnostic endpoints become public without any explicit routing code.
+**Prevention:** Do not import `net/http/pprof` or `expvar` in binaries exposed to the public internet. If profiling is needed, configure a separate HTTP server strictly bound to a local or internal network address to serve these endpoints.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was importing `net/http/pprof` and `expvar` via `_` in `cmd/tesseract/posix/main.go`, which automatically registers internal diagnostic endpoints (like `/debug/pprof/*` and `/debug/vars`) on the `http.DefaultServeMux`. This exposes sensitive application profiling and memory metrics over the public HTTP interface (CWE-200).
🎯 Impact: Attackers could gain deep insights into internal application behavior, memory usage, and execution profiles, which could be leveraged to identify further vulnerabilities or execute Denial of Service (DoS) attacks.
🔧 Fix: Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go` to prevent the automatic registration on the public multiplexer.
✅ Verification: Ran `go build ./...` and `go test ./... -short` successfully. Checked via `grep` that the imports are no longer present.

---
*PR created automatically by Jules for task [5323559867267601866](https://jules.google.com/task/5323559867267601866) started by @phbnf*