### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposed profiling and metrics endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-27 - Exposed Profiling and Metrics Endpoints (CWE-200)
+**Vulnerability:** The POSIX cloud personality (`cmd/tesseract/posix/main.go`) imported `_ "net/http/pprof"` and `_ "expvar"`, which automatically registered `/debug/pprof/*` and `/debug/vars` handlers on `http.DefaultServeMux`. Since the HTTP server was started without explicitly configuring a `Handler`, it defaulted to `http.DefaultServeMux`, making these debug endpoints public and exposing internal application state and metrics.
+**Learning:** Default multiplexers like `http.DefaultServeMux` should be avoided when creating public-facing HTTP servers, or imports like `net/http/pprof` and `expvar` must be strictly omitted, as they register themselves globally.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in entry point binaries unless debug endpoints are specifically required and protected by authentication/authorization mechanisms or bound to an internal-only port.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Information Exposure (CWE-200) via publicly accessible `/debug/pprof/*` and `/debug/vars` endpoints.
🎯 Impact: Attackers could access internal memory profiles, goroutine traces, and internal metrics (like BadgerDB statistics). This exposes sensitive internal state that could be used to reverse engineer the application's performance characteristics or find further vulnerabilities.
🔧 Fix: Removed the blank identifier imports (`_ "net/http/pprof"` and `_ "expvar"`) from `cmd/tesseract/posix/main.go`, preventing them from registering their debug handlers on `http.DefaultServeMux`.
✅ Verification: Ran `go build` and `go test ./...` to ensure no functionality is broken, and verified the imports no longer exist in the file.

---
*PR created automatically by Jules for task [9337263916733553880](https://jules.google.com/task/9337263916733553880) started by @phbnf*