### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Exposed Profiling Endpoint (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-10-24 - Exposed Profiling Endpoint (CWE-200) in posix personality
+**Vulnerability:** The `posix` personality exposed Go profiling (`net/http/pprof`) and `expvar` variables globally on the default `http.ServeMux` due to anonymous imports (`_ "net/http/pprof"` and `_ "expvar"`).
+**Learning:** Anonymous imports of diagnostic packages bind to the default global multiplexer, exposing sensitive internal state, memory details, and potentially allowing DoS attacks on production endpoints unless explicitly secured or firewalled.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` or `expvar` in production binaries. If profiling is needed, explicitly mount it on an internal, authenticated, or separate administrative port, rather than the primary public-facing HTTP server.

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removed anonymous imports of `net/http/pprof` and `expvar` from the `cmd/tesseract/posix/main.go` entrypoint to prevent exposure of debugging endpoints on `http.DefaultServeMux`, fixing a CWE-200 vulnerability. Also recorded the finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5393104722091764508](https://jules.google.com/task/5393104722091764508) started by @phbnf*