### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-02 - Prevent CWE-200 by avoiding net/http/pprof auto-exposure
+**Vulnerability:** Profiling and metric endpoints were exposed via `net/http/pprof` because it was imported blindly. `net/http/pprof` registers endpoints on the default `http.DefaultServeMux` upon import.
+**Learning:** In Go, handlers exposing debugging tools can leak internal runtime information which is a security risk. Importing `net/http/pprof` specifically is highly dangerous unless deliberately isolated behind restricted access endpoints or entirely decoupled from public-facing multiplexers.
+**Prevention:** Do not import `_ "net/http/pprof"`. If profiling is required, manually register its handlers on a dedicated internal mux rather than on `http.DefaultServeMux`, ensuring standard applications only register necessary HTTP endpoints.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The standard `net/http/pprof` package was imported in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. In Go, blindly importing this package automatically registers multiple profiling endpoints (like `/debug/pprof/`) on `http.DefaultServeMux`.
🎯 **Impact:** If `http.DefaultServeMux` is exposed publicly or even internally without strict access controls, attackers or unauthorized users can access rich runtime data (goroutines, heap memory, CPU profiles). This leaks internal execution metrics and can facilitate further attacks or DoS.
🔧 **Fix:** Removed the `_ "net/http/pprof"` imports from the respective binaries. If profiling is strictly required in the future, it should be manually registered on an isolated and restricted internal server mux. Documented this learning in `.jules/sentinel.md`.
✅ **Verification:** Verified by checking that `net/http/pprof` is no longer imported in `cmd/tesseract/*/main.go` and ensuring the binaries successfully compile.

---
*PR created automatically by Jules for task [8752632264065594111](https://jules.google.com/task/8752632264065594111) started by @phbnf*