### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of profiling and metrics endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-03 - Mitigate global http.DefaultServeMux exposure
+**Vulnerability:** Automatically exposing the profiling endpoints (/debug/pprof) and variables endpoints (/debug/vars) globally on http.DefaultServeMux via blank imports. This could inadvertently expose sensitive debugging information or provide a vector for Denial of Service if the main application router is or falls back to http.DefaultServeMux without proper access controls (CWE-200).
+**Learning:** Adding debugging endpoints should be an explicit and controlled process, not automatic through side-effect imports in main deployment files.
+**Prevention:** Avoid using `_ "net/http/pprof"` and `_ "expvar"` in entry points, especially for services deployed to cloud environments (like posix and gcp in this codebase). If pprof or expvar is needed, their handlers should be explicitly registered to a dedicated, protected serve mux.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Automatic exposure of profiling (`/debug/pprof`) and variables (`/debug/vars`) endpoints globally on `http.DefaultServeMux` via blank imports. This could inadvertently expose sensitive debugging information or provide a vector for DoS if the main application router is or falls back to `http.DefaultServeMux` without proper access controls (CWE-200).
🎯 **Impact**: Potential leakage of sensitive internal metrics, heap/CPU profiles, command-line arguments, and memory addresses, which an attacker could use for reconnaissance or Denial of Service.
🔧 **Fix**: Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. Adding debugging endpoints should be an explicit and controlled process, not automatic through side-effect imports in main deployment files.
✅ **Verification**: Verified using `go test ./...` and `gosec` that the imports are gone and no further CWE-200 issues of this type remain in these entry points.

---
*PR created automatically by Jules for task [4603034456282391436](https://jules.google.com/task/4603034456282391436) started by @phbnf*