### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposed pprof and expvar endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-20 - [HIGH] Fix exposed pprof and expvar endpoints
+**Vulnerability:** The codebase inadvertently imports `net/http/pprof` and `expvar` using the blank identifier (`_ "net/http/pprof"`) in the cloud personality entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`).
+**Learning:** Importing these packages with a blank identifier automatically registers their profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the `http.DefaultServeMux`. If this mux is exposed to the public internet, it can lead to CWE-200 vulnerabilities by leaking sensitive information about the application's runtime and environment.
+**Prevention:** Avoid blank imports of `net/http/pprof` and `expvar` in production entry points. For monitoring and profiling in production, consider safer alternatives or bind the default multiplexer to a local or internal network interface only.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
This PR addresses a high-severity security issue (CWE-200) caused by the blank import of `net/http/pprof` and `expvar`. When these packages are imported with the blank identifier, they automatically register their profiling and variables endpoints (`/debug/pprof/*` and `/debug/vars`) on the default `http.DefaultServeMux`. Since these entry points can be exposed, this could leak sensitive runtime information to unauthenticated users. The fix removes these imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Additionally, a `.jules/sentinel.md` journal entry was created to document the learning.

---
*PR created automatically by Jules for task [6069344865819692858](https://jules.google.com/task/6069344865819692858) started by @phbnf*