### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [CWE-200] Exposure of Profiling Endpoints
+**Vulnerability:** Profiling endpoints (`/debug/pprof/*` and `/debug/vars`) were inadvertently exposed on the global `http.DefaultServeMux` by importing `_ "net/http/pprof"` and `_ "expvar"` in the public-facing cloud personality entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`). This can lead to information leakage (CWE-200).
+**Learning:** Importing `net/http/pprof` or `expvar` automatically registers handlers on the `http.DefaultServeMux`. If a custom HTTP server is not carefully configured to use a separate multiplexer, or if the default multiplexer is used for public traffic, these sensitive endpoints become publicly accessible.
+**Prevention:** Avoid importing `net/http/pprof` and `expvar` in production entry points unless explicitly required and securely configured (e.g., bound to a separate, internal-only port or protected by authentication).

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The profiling endpoints (`/debug/pprof/*` and `/debug/vars`) were inadvertently exposed on the global `http.DefaultServeMux` because `_ "net/http/pprof"` and `_ "expvar"` were imported in the public-facing cloud personality entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`).
🎯 **Impact:** Exposing these endpoints publicly can lead to information leakage (CWE-200), allowing attackers to gain sensitive insights into runtime memory, internal state, and environment details. It could also lead to a Denial of Service (DoS) if profiling features are repeatedly triggered.
🔧 **Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` blank imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Ran `gosec -exclude=G304,G101,G115 -fmt=json -out=gosec-report-updated.json ./...` and verified that the "Profiling endpoint is automatically exposed on /debug/pprof" warnings were eliminated. All tests pass.

---
*PR created automatically by Jules for task [13587957713631628448](https://jules.google.com/task/13587957713631628448) started by @phbnf*