### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix context cancellation leaks (CWE-400)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+## 2025-01-01 - Initializing Sentinel Journal
+
+## 2025-02-09 - Fix Context Cancellation Leaks (CWE-400)
+**Vulnerability:** Found multiple context cancellation leaks (CWE-400, gosec G118) where `context.WithCancel` was used without an immediate `defer cancel()` to ensure resources are released upon function exit. This occurred in `cmd/fsck/main.go`, `internal/hammer/hammer.go`, and worker goroutines in `internal/hammer/loadtest/workers.go`.
+**Learning:** Even if `cancel()` is explicitly called later or passed to another struct, returning early without a `defer cancel()` leads to memory leaks where context resources (and associated goroutines) aren't properly cleaned up.
+**Prevention:** Always explicitly call `defer cancel()` immediately after creating a context with `context.WithCancel` to ensure resources are freed, even if an early return happens or if explicit cancellation handles the normal execution flow.

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -125,6 +125,7 @@ func main() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	logSigV, err := logSigVerifier(*origin, *logPubKey)
 	if err != nil {

--- a/internal/hammer/loadtest/workers.go
+++ b/internal/hammer/loadtest/workers.go
@@ -79,6 +79,7 @@ func (r *LeafReader) Run(ctx context.Context) {
 		panic("LeafReader was ran multiple times")
 	}
 	ctx, r.cancel = context.WithCancel(ctx)
+	defer r.cancel()
 	for {
 		select {
 		case <-ctx.Done():
@@ -221,6 +222,7 @@ func (w *LogWriter) Run(ctx context.Context) {
 		panic("LogWriter was run multiple times")
 	}
 	ctx, w.cancel = context.WithCancel(ctx)
+	defer w.cancel()
 	newLeaf := w.gen()
 	for {
 		select {
@@ -303,6 +305,7 @@ func (v *MMDVerifier) Run(ctx context.Context) {
 		panic("MMDVerifier was ran multiple times")
 	}
 	ctx, v.cancel = context.WithCancel(ctx)
+	defer v.cancel()
 
 	var checkpoint log.Checkpoint
 	var proofBuilder *client.ProofBuilder


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix context cancellation leaks (CWE-400)

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Un-deferred `context.WithCancel` usage found in `internal/hammer/hammer.go` and `internal/hammer/loadtest/workers.go`.
🎯 **Impact:** If these long-running worker tasks return early due to errors or timeouts, failing to immediately call `defer cancel()` leads to memory leaks and resource exhaustion (CWE-400), as child goroutines and internal context state are never freed.
🔧 **Fix:** Added `defer cancel()` immediately after context creation to ensure deterministic resource cleanup.
✅ **Verification:** Verified fix using `grep` and executed the test suite to ensure no regressions were introduced. Evaluated and explicitly avoided false-positive/security theater fixes in CLI commands (`cmd/fsck/main.go`) to prevent deadlocks.

---
*PR created automatically by Jules for task [16963423122963598517](https://jules.google.com/task/16963423122963598517) started by @phbnf*