### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-11 - Prevent Information Exposure via pprof and expvar Endpoints (CWE-200)
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` automatically exposed profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints on the global `http.DefaultServeMux`. These endpoints can reveal sensitive application internals and potential memory/CPU consumption patterns to attackers.
+**Learning:** Default behavior of these packages directly modifies the global state, making it surprisingly easy to unintentionally expose internal diagnostics in production binaries.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in production entry points. If profiling is needed, register endpoints explicitly on an internal, authenticated multiplexer instead of the globally exposed `http.DefaultServeMux`.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` in production entry points (`posix` and `gcp`) automatically registered profiling and metric endpoints on the global `http.DefaultServeMux`. 
🎯 **Impact:** Exposing these endpoints publicly allows unauthenticated attackers to view sensitive application internals, system metrics, and memory/CPU profiling data, constituting a CWE-200 Information Exposure vulnerability.
🔧 **Fix:** Removed the anonymous `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. Also added a `.jules/sentinel.md` entry.
✅ **Verification:** Run static analysis `gosec -exclude=G304,G101,G115 ./...` to verify rule G108 no longer fires. Run `go test ./... -short` to ensure tests continue to pass.

---
*PR created automatically by Jules for task [15205376547789544292](https://jules.google.com/task/15205376547789544292) started by @phbnf*