### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Information Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Prevent Information Exposure via pprof and expvar
+**Vulnerability:** The cloud personality entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`) import `net/http/pprof` and `expvar`. This unintentionally registers profiling and metric endpoints (`/debug/pprof/*` and `/debug/vars`) on the default HTTP multiplexer `http.DefaultServeMux`, leading to a CWE-200 vulnerability by exposing internal application data publicly.
+**Learning:** Anonymous imports for profiling and debugging should never be used in production applications, especially on public-facing servers.
+**Prevention:** Remove anonymous imports of `net/http/pprof` and `expvar` from the entry point packages. Use explicit, isolated routes for debugging if necessary, or rely on existing observability frameworks (like OpenTelemetry in this project) instead of default HTTP debug handlers.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH (CWE-200)
💡 Vulnerability: Anonymous imports of `net/http/pprof` and `expvar` automatically register internal debugging, profiling, and metrics endpoints on the default HTTP multiplexer.
🎯 Impact: An attacker could access sensitive memory profiles, application state, and metrics if the default multiplexer is exposed publicly.
🔧 Fix: Removed the anonymous imports from the GCP and POSIX cloud personality entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`).
✅ Verification: Ran `grep -r -E "(net/http/pprof|expvar)" cmd/tesseract/` to verify absence. Checked that test suite passes using `go test ./... -short`.

---
*PR created automatically by Jules for task [8196081919631315178](https://jules.google.com/task/8196081919631315178) started by @phbnf*