### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Information Exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Information Exposure via DefaultServeMux
+**Vulnerability:** Information Exposure (CWE-200) due to blanket imports `_ "net/http/pprof"` and `_ "expvar"`.
+**Learning:** In Go, anonymously importing `net/http/pprof` or `expvar` automatically registers HTTP endpoints (e.g. `/debug/pprof/*`, `/debug/vars`) onto the global `http.DefaultServeMux`. If an application relies on `http.DefaultServeMux` for any public-facing HTTP server, these profiling and metrics endpoints become publicly accessible, potentially exposing sensitive internal runtime information.
+**Prevention:** Avoid blanket importing `net/http/pprof` or `expvar` in main packages for cloud personalities or any publicly accessible HTTP server entry points. If profiling or metrics are required, explicitly register them on an internal or protected router/multiplexer, or use an observability framework like OpenTelemetry.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
### 🚨 Severity: CRITICAL
### 💡 Vulnerability: Information Exposure (CWE-200)
Anonymously importing `net/http/pprof` and `expvar` in Go automatically registers handlers for profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) onto the global `http.DefaultServeMux`.

### 🎯 Impact
If a service uses `http.DefaultServeMux` for any public-facing HTTP server, these sensitive internal metrics and runtime profiles become publicly accessible to unauthenticated attackers, leading to severe information leakage.

### 🔧 Fix
Removed the `_ "net/http/pprof"` and `_ "expvar"` blanket imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Added a corresponding journal entry in `.jules/sentinel.md` documenting this standard Go security footgun.

### ✅ Verification
1. `go test ./... -short` passes successfully.
2. The blanket imports are no longer present.

---
*PR created automatically by Jules for task [15063300200593567658](https://jules.google.com/task/15063300200593567658) started by @phbnf*