### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix exposed pprof and expvar endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Prevent unintentional exposure of profiling data
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go` exposed profiling data (`/debug/pprof/*` and `/debug/vars`) on the default HTTP multiplexer (CWE-200).
+**Learning:** Using `_ "net/http/pprof"` and `_ "expvar"` automatically registers sensitive metrics endpoints globally, making them accessible to any client hitting the service, unless the server explicitly defines a custom routing mux that excludes them.
+**Prevention:** Never use anonymous imports for pprof or expvar in production entry points unless explicitly configuring them on a secure, internal-only HTTP server.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Anonymous imports of `net/http/pprof` and `expvar` in the `gcp` and `posix` entry points registered sensitive profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on `http.DefaultServeMux`. This leads to a CWE-200 Information Exposure vulnerability.
🎯 Impact: Attackers could access execution profiles, memory usage, and internal BadgerDB metrics, potentially revealing sensitive information about the server's internal state and assisting in further attacks.
🔧 Fix: Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from the affected `main.go` files to prevent the endpoints from being globally registered.
✅ Verification: Ensure the application builds and tests pass. Confirm that navigating to `/debug/pprof/` or `/debug/vars` on the running application now returns a 404 Not Found instead of internal data.

---
*PR created automatically by Jules for task [12190058162179666523](https://jules.google.com/task/12190058162179666523) started by @phbnf*