### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix exposed profiling endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Exposed Profiling and Metrics Endpoints (CWE-200)
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) handlers on the global `http.DefaultServeMux`. If `http.DefaultServeMux` is exposed via a public-facing `http.Server`, this leaks sensitive operational and memory profiling data.
+**Learning:** Framework-level convenience features like anonymous imports modify global state in ways that are easily overlooked and can have severe security implications when default multiplexers are used.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar`. If profiling or metrics are required, explicitly register them on a dedicated internal multiplexer bound to a private network interface or protected port, separate from the public-facing HTTP server.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) handlers on the global `http.DefaultServeMux`. If `http.DefaultServeMux` is exposed via a public-facing `http.Server`, this leaks sensitive operational and memory profiling data.
🎯 Impact: Attackers can access `/debug/pprof/*` and `/debug/vars` to gather sensitive operational data, memory dumps, and potentially exploit other vulnerabilities.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` anonymous imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
✅ Verification: Ran `gosec` to verify G108 rules are no longer flagged for these files. Ran `go build ./...` and `go test ./... -short` to ensure no functionality is broken. Added a critical learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17447662431792467489](https://jules.google.com/task/17447662431792467489) started by @phbnf*