### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-02-23 - Prevent Profile and Debug Endpoint Exposure (CWE-200)
+
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` in HTTP server entrypoints (e.g., `cmd/tesseract/gcp/main.go`, `cmd/tesseract/posix/main.go`) automatically register endpoints on the global `http.DefaultServeMux`. If `http.DefaultServeMux` is unintentionally exposed or used by public-facing multiplexers without proper routing filters, it leaks sensitive debugging metrics and profiling data.
+
+**Learning:** Blank imports like `_ "net/http/pprof"` mutate global state during initialization, which often goes unnoticed when bringing up HTTP servers, thereby exposing unintended attack surface on default HTTP handler setups.
+
+**Prevention:** Avoid using anonymous imports for `pprof` or `expvar` in production entrypoints. Instead, if metrics are required, selectively register them onto internal, restricted, or administrative muxes explicitly rather than relying on global side-effects.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: CWE-200 - Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling and metrics endpoints to the global `http.DefaultServeMux`, inadvertently exposing sensitive internal data.
🎯 **Impact**: An attacker could access debugging endpoints (`/debug/pprof/*`, `/debug/vars`) to profile the application, gather internal memory layouts, BadgerDB metrics, or cause a denial of service by triggering expensive CPU profiles.
🔧 **Fix**: Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ **Verification**: Run `go test ./... -short` to ensure tests pass, and verify using `grep` that `pprof` and `expvar` are no longer imported in the entrypoints.

---
*PR created automatically by Jules for task [3365752228405677151](https://jules.google.com/task/3365752228405677151) started by @phbnf*