### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of profiling endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-15 - Exposure of profiling endpoints (CWE-200)
+**Vulnerability:** The posix and gcp cloud personalities were exposing `net/http/pprof` and `expvar` on the default HTTP multiplexer via anonymous imports.
+**Learning:** Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the globally accessible `http.DefaultServeMux`, leading to CWE-200.
+**Prevention:** Do not use anonymous imports for `net/http/pprof` or `expvar` in production applications. If profiling is needed, register handlers manually on an internal-only multiplexer (on a separate port).

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix exposure of profiling endpoints (CWE-200)

🚨 Severity: HIGH
💡 Vulnerability: The posix and gcp cloud personalities were exposing `net/http/pprof` and `expvar` on the default HTTP multiplexer via anonymous imports. This automatically registers profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the globally accessible `http.DefaultServeMux`, leading to CWE-200 (Information Exposure).
🎯 Impact: Attackers could access internal metrics, database metrics, and application memory profiles, leading to information leakage.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
✅ Verification: `go test ./... -short` passed, and `grep` confirms the imports have been removed. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1208568423795799137](https://jules.google.com/task/1208568423795799137) started by @phbnf*