### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of profiling and metrics endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Prevent exposing profiling and metrics endpoints (CWE-200)
+**Vulnerability:** Profiling endpoints (`net/http/pprof`) and metrics endpoints (`expvar`) were inadvertently exposed on public-facing servers via `http.DefaultServeMux` due to anonymous imports.
+**Learning:** In Go, anonymously importing `net/http/pprof` or `expvar` automatically registers handlers on the global `http.DefaultServeMux`. If an application uses `http.DefaultServeMux` for its public API or is exposed without a reverse proxy filtering these routes, sensitive runtime data (profiling, metrics) is leaked.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` or `expvar` in production binaries unless explicitly configuring a separate, secure, private server for them. Use alternative profiling or metrics gathering (like OpenTelemetry) that don't implicitly bind to the default mux.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH (CWE-200)
💡 Vulnerability: Profiling (`net/http/pprof`) and metric endpoints (`expvar`) were exposed via anonymous imports, binding to `http.DefaultServeMux` and potentially leaking sensitive operational data on public servers.
🎯 Impact: Attackers or unauthorized users could scrape runtime performance stats, view system behavior, or cause degraded performance by accessing default `/debug/pprof` or `/debug/vars` endpoints on exposed servers.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` imports from production binaries in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ Verification: Ensure the app builds and that `/debug/pprof/` and `/debug/vars` are no longer reachable. Running `gosec` locally will no longer report G108 rules regarding these imports.

---
*PR created automatically by Jules for task [5067847074509108889](https://jules.google.com/task/5067847074509108889) started by @phbnf*