### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Information Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-24 - Exposing Profiling Endpoints via http.DefaultServeMux
+**Vulnerability:** `net/http/pprof` and `expvar` were anonymously imported in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This automatically exposes profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints on the globally accessible `http.DefaultServeMux`, leading to potential information disclosure (CWE-200).
+**Learning:** Anonymous imports of standard library profiling and metrics packages implicitly bind to the default global multiplexer. When this multiplexer is used or exposed via public-facing servers without proper routing restrictions, sensitive internal state is leaked.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in entrypoints that launch public-facing HTTP servers. If profiling or metrics are required, explicitly bind them to a separate, private, internal multiplexer and listen on an internal-only port or interface.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Anonymous imports of `net/http/pprof` and `expvar` automatically bound profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints to the global `http.DefaultServeMux`. Exposing this mux publicly leaks sensitive internal application state.
🎯 **Impact**: Information disclosure, allowing potential attackers to view application memory profiles, goroutine traces, and internal metrics.
🔧 **Fix**: Removed the anonymous `net/http/pprof` and `expvar` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
✅ **Verification**: Run `gosec` and verify that the CWE-200 findings related to the profiling endpoints are no longer present.

---
*PR created automatically by Jules for task [889288285944902955](https://jules.google.com/task/889288285944902955) started by @phbnf*