### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 by removing anonymous imports of pprof and expvar

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-26 - Prevent CWE-200 by avoiding anonymous imports of pprof and expvar
+**Vulnerability:** The `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` files had anonymous imports of `net/http/pprof` and `expvar`. This automatically registered profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the globally exposed `http.DefaultServeMux`, which could lead to an information exposure vulnerability (CWE-200).
+**Learning:** Cloud personalities utilize OpenTelemetry (otel) for handlers and deliberately avoid exposing `net/http/pprof` endpoints. Exposing these globally by mistake can leak sensitive operational data to unauthorized actors. BadgerDB metrics in the posix personality shouldn't be exposed globally.
+**Prevention:** Avoid using anonymous imports of `net/http/pprof` and `expvar` in files that start `http.Server` entry points, especially those using `http.DefaultServeMux`. Cloud handlers use structured otel reporting instead.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` files had anonymous imports of `net/http/pprof` and `expvar`. This automatically registered profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the globally exposed `http.DefaultServeMux`, which could lead to an information exposure vulnerability (CWE-200).
🎯 Impact: Unauthorized actors could access sensitive operational metrics, memory profiles, CPU profiles, BadgerDB metrics, and command-line arguments, aiding in further attacks.
🔧 Fix: Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from the `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` entry points to prevent accidental global exposure. Cloud personalities correctly utilize structured OpenTelemetry reporting instead. Documented the fix in the `.jules/sentinel.md` journal.
✅ Verification: Ensure the application starts normally and test fetching paths like `/debug/pprof/` and `/debug/vars`; they should now return a 404 instead of sensitive data. Tests have been run with `go test ./... -short` to ensure no regressions.

---
*PR created automatically by Jules for task [4717492118710897646](https://jules.google.com/task/4717492118710897646) started by @phbnf*