### PR TITLE
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - Remove exposed pprof and expvar endpoints
+**Vulnerability:** Automatically exposed profiling endpoints (`/debug/pprof/*`) and variables (`/debug/vars`) via anonymous imports of `net/http/pprof` and `expvar` (CWE-200).
+**Learning:** Anonymous imports of these packages automatically bind to `http.DefaultServeMux`, which may unintentionally expose sensitive performance and environment data on the primary HTTP listener.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar`. If profiling is needed, explicitly configure and serve it on a separate, protected listener/port.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removed anonymous `_ "net/http/pprof"` and `_ "expvar"` imports from the entrypoints to prevent inadvertent exposure of sensitive debugging and profiling endpoints.

---
*PR created automatically by Jules for task [17548614275495078403](https://jules.google.com/task/17548614275495078403) started by @phbnf*