### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposed pprof and expvar endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-28 - Information Exposure via Profiling and Metrics Endpoints (CWE-200)
+**Vulnerability:** The profiling endpoint `net/http/pprof` and metrics endpoint `expvar` were anonymously imported in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`, inadvertently exposing `/debug/pprof/*` and `/debug/vars` on `http.DefaultServeMux`.
+**Learning:** Anonymous imports of `net/http/pprof` and `expvar` in entry points that use the default HTTP ServeMux for cloud personalities can expose sensitive profiling and metrics data, creating CWE-200 vulnerabilities. Cloud personalities should utilize OpenTelemetry (otel) instead.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in entry point packages unless specifically required, and never on public-facing endpoints using the default serve mux.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Information Exposure (CWE-200) due to anonymous imports of `net/http/pprof` and `expvar` exposing internal profiling and metrics endpoints.
🎯 **Impact:** Exposes internal system details, performance metrics, and application memory state to unauthenticated attackers.
🔧 **Fix:** Removed the offending anonymous imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ **Verification:** Ensured the endpoints are no longer exposed and all tests pass via `go test ./... -short`.
📝 **Journaled:** Created a learning entry in `.jules/sentinel.md` regarding this issue.

---
*PR created automatically by Jules for task [11770764839162008815](https://jules.google.com/task/11770764839162008815) started by @phbnf*