### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix CWE-200 Information Exposure via Exposed pprof/expvar

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-29 - Prevent CWE-200 by avoiding anonymous imports of pprof and expvar
+**Vulnerability:** Information exposure (CWE-200) via exposed profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints.
+**Learning:** Anonymous imports of `net/http/pprof` and `expvar` automatically register their respective endpoints on the globally accessible `http.DefaultServeMux`. If an application exposes this default mux on a public-facing port, it inadvertently exposes sensitive runtime metrics and profiling capabilities.
+**Prevention:** Avoid using anonymous imports (`_ "net/http/pprof"` and `_ "expvar"`) in production code, particularly in HTTP server entry points. If profiling or metrics are required, explicitly register them on an internal, authenticated, or non-public multiplexer, separate from the main application traffic.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Exposure (CWE-200). The HTTP server entry points for GCP and POSIX were anonymously importing `net/http/pprof` and `expvar`. These packages automatically register their respective endpoints (`/debug/pprof/*` and `/debug/vars`) on `http.DefaultServeMux`. If the server exposes this default mux, it inadvertently exposes sensitive runtime metrics and profiling capabilities.
🎯 **Impact:** Exposing application metrics and profiling information to unauthorized actors can leak internal application state, aid in discovering other vulnerabilities, and provide insight into system performance or potential denial-of-service vectors.
🔧 **Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Telemetry and profiling should be explicitly routed to an internal or authenticated mux if needed. Added a learning log in `.jules/sentinel.md`.
✅ **Verification:** Ran `go test ./... -short` successfully. Checked that the files no longer contain the anonymous imports.

---
*PR created automatically by Jules for task [8304257674238574009](https://jules.google.com/task/8304257674238574009) started by @phbnf*