### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of profiling and metrics endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-30 - Exposure of Profiling and Metrics Endpoints (CWE-200)
+**Vulnerability:** The GCP and POSIX entry points in `cmd/tesseract` were importing `_ "net/http/pprof"` and `_ "expvar"`. This caused profiling and metric endpoints (`/debug/pprof/*` and `/debug/vars`) to be automatically registered and exposed on `http.DefaultServeMux`.
+**Learning:** Anonymous imports of standard library debugging tools can silently expose sensitive internal endpoints to the internet if `http.DefaultServeMux` is bound to a public interface.
+**Prevention:** Avoid using anonymous imports for debugging packages in production binaries, especially when creating custom server multiplexers, and always verify what routes are registered on the public listener.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The GCP and POSIX `tesseract` entry points were importing `_ "net/http/pprof"` and `_ "expvar"`. This automatically registers internal profiling and metric routes (`/debug/pprof/*` and `/debug/vars`) to `http.DefaultServeMux`. If the server binds this default multiplexer to a public interface, it exposes internal application state and potential denial of service vectors (CWE-200).
🎯 Impact: An attacker could access sensitive internal performance metrics, memory profiles, or trigger CPU-intensive profiling tasks if the default multiplexer is internet-facing.
🔧 Fix: Removed the insecure anonymous imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ Verification: Ensure no `pprof` or `expvar` routes are exposed and run `go test ./... -short` to confirm server stability.

Additionally, added a Sentinel journal entry in `.jules/sentinel.md` documenting this learning.

---
*PR created automatically by Jules for task [10693408181395756026](https://jules.google.com/task/10693408181395756026) started by @phbnf*