### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-28 - Removed global pprof endpoints
+
+**Vulnerability:** Information Disclosure (CWE-200). `net/http/pprof` endpoints were exposed by anonymous imports (`_ "net/http/pprof"`) on the globally accessible `http.DefaultServeMux` in the `posix` and `gcp` entries. The `posix` entry point was also exposing `expvar`. This exposed profiling info and metrics directly on public-facing servers.
+**Learning:** Anonymous imports of diagnostic packages automatically register handlers to `http.DefaultServeMux`. If `http.ListenAndServe()` is started using `DefaultServeMux` or a custom router without strict isolation, these diagnostic endpoints become public.
+**Prevention:** Remove anonymous imports of `net/http/pprof` and `expvar` in production entry points. If profiling or metrics are required, explicitly register them on a separate `http.ServeMux` that is only exposed internally (e.g., bound to `localhost` or behind an internal load balancer/auth proxy). Use `otel` or similar telemetry frameworks deliberately rather than implicitly exposing `net/http/pprof` endpoints.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Information Disclosure (CWE-200). `net/http/pprof` endpoints were exposed by anonymous imports (`_ "net/http/pprof"`) on the globally accessible `http.DefaultServeMux` in the `posix` and `gcp` entries. The `posix` entry point was also exposing `expvar`. This exposed profiling info and metrics directly on public-facing servers.
🎯 Impact: Attackers could access internal diagnostic endpoints (e.g. `/debug/pprof/*`, `/debug/vars`) to gather sensitive performance, memory, and runtime environment details about the production server.
🔧 Fix: Removed the anonymous imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Telemetry and metrics are intentionally gathered and exported via OpenTelemetry (`otel`) without relying on the default ServeMux.
✅ Verification: Tested via unit tests (`go test ./... -short`) and statically verified that no other occurrences of these diagnostic imports exist in `cmd/tesseract/` packages using `grep`.

---
*PR created automatically by Jules for task [14800212077039988699](https://jules.google.com/task/14800212077039988699) started by @phbnf*