### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-02 - Fix CWE-200 profiling and metrics endpoint exposure
+**Vulnerability:** The application was importing `_ "net/http/pprof"` and `_ "expvar"` in binaries that start HTTP servers configured to use the global `http.DefaultServeMux`. This automatically registered and exposed profiling endpoints (`/debug/pprof/*`) and internal metrics (`/debug/vars`) publicly.
+**Learning:** In Go, anonymous imports of `net/http/pprof` and `expvar` automatically add routes to `http.DefaultServeMux`. If a custom public-facing server uses this mux (e.g., via `http.Handle("/", handler)` without defining a custom router), these endpoints are inadvertently exposed, resulting in a CWE-200 vulnerability.
+**Prevention:** Avoid using anonymous imports of `net/http/pprof` and `expvar` in code that runs public-facing HTTP servers using `http.DefaultServeMux`. If profiling or metrics are needed, register them to a private or authenticated multiplexer instead.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was importing `_ "net/http/pprof"` and `_ "expvar"` in binaries that start HTTP servers configured to use the global `http.DefaultServeMux`. This automatically registered and exposed profiling endpoints (`/debug/pprof/*`) and internal metrics (`/debug/vars`) publicly (CWE-200).
🎯 **Impact:** Exposes sensitive internal application metrics, performance data, and environment information to unauthorized external users.
🔧 **Fix:** Removed the anonymous imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. Documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Run `go test ./...` and ensure `gosec` no longer flags G108 (pprof). Ensure `/debug/pprof` and `/debug/vars` routes are no longer registered on the global mux.

---
*PR created automatically by Jules for task [17346520998165019005](https://jules.google.com/task/17346520998165019005) started by @phbnf*