### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-200 /debug/pprof and /debug/vars exposure on DefaultServeMux

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-05 - Remove default pprof/expvar handlers from default ServeMux
+**Vulnerability:** The codebase had imports for `_ "net/http/pprof"` in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`, and `_ "expvar"` in `cmd/tesseract/posix/main.go`. This automatically exposes profiling endpoint `/debug/pprof/*` and metrics endpoint `/debug/vars` on `http.DefaultServeMux`, leading to potential CWE-200 vulnerabilities (exposure of sensitive information).
+**Learning:** These side-effect imports expose debug endpoints indiscriminately on the global multiplexer, which might be publicly accessible when creating the main HTTP server without explicitly defining a private multiplexer for them.
+**Prevention:** Avoid side-effect imports of `net/http/pprof` or `expvar`. If debug endpoints are needed, register them explicitly on an internal, authenticated, or port-separated multiplexer.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The codebase included imports for `_ "net/http/pprof"` and `_ "expvar"` in the GCP and Posix entrypoints. These side-effect imports automatically register `/debug/pprof/*` and `/debug/vars` handlers onto the global `http.DefaultServeMux`, which can unintentionally expose sensitive application internals, performance profiling data, and BadgerDB metrics to the public.
🎯 Impact: Attackers could access exposed metrics and profiling info (CWE-200), providing them with internal structure, potentially sensitive queries or parameters in memory, and system performance insights which can aid in further exploitation.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` side-effect imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
✅ Verification: `go test ./... -short` passed. I verified via `grep` that `pprof` and `expvar` imports are no longer present in the codebase's production entry points.

Also added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2372403483926053237](https://jules.google.com/task/2372403483926053237) started by @phbnf*