### PR TITLE
🛡️ Sentinel: [HIGH] Fix profiling endpoint exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-06 - Prevent CWE-200 Information Exposure via DefaultServeMux
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` automatically register handlers on `http.DefaultServeMux`. If an application uses `http.DefaultServeMux` for public-facing servers without restriction, it inadvertently exposes sensitive profiling data and metrics (CWE-200).
+**Learning:** These side-effect imports are often added for debugging and forgotten, leaking internal state to anyone who can reach the HTTP server.
+**Prevention:** Avoid `_ "net/http/pprof"` and `_ "expvar"` in production binaries. If profiling or metric endpoints are needed, register them explicitly on a dedicated, internal-only `http.ServeMux` that is not exposed to the public network.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removes anonymous imports of `net/http/pprof` and `expvar` from public-facing server entry points to prevent accidental exposure of internal profiling data and metrics on `http.DefaultServeMux` (CWE-200).

---
*PR created automatically by Jules for task [4390061245120312713](https://jules.google.com/task/4390061245120312713) started by @phbnf*