### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-200 Information Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-06-07 - CWE-200: Profiling Endpoint Exposure
+
+**Vulnerability:** The `net/http/pprof` and `expvar` packages were imported in the production binaries (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`). These packages automatically register endpoints like `/debug/pprof/*` and `/debug/vars` on the global `http.DefaultServeMux`, which is exposed to the internet.
+
+**Learning:** This exposes sensitive internal application state and profiling endpoints to anyone who can access the public server, which is a significant Information Exposure vulnerability (CWE-200).
+
+**Prevention:** Never import `net/http/pprof` or `expvar` in production entry points without robust authentication/authorization. Rely on internal monitoring solutions (like OpenTelemetry, which is already used in this codebase) instead.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Information Exposure (CWE-200) via exposed `pprof` and `expvar` HTTP endpoints on `http.DefaultServeMux`.
🎯 Impact: Attackers or unauthorized users could access internal profiling data, memory statistics, and application metrics, potentially revealing sensitive internal state or aiding in further attacks.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` imports from production binary entrypoints (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`).
✅ Verification: Ran `go test ./... -short` and manually verified that `/debug/pprof/` and `/debug/vars` are no longer registered by these imports.

---
*PR created automatically by Jules for task [12390574555677607630](https://jules.google.com/task/12390574555677607630) started by @phbnf*