### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - Prevent pprof endpoint exposure on public servers
+**Vulnerability:** Importing _ "net/http/pprof" or _ "expvar" automatically registers debug endpoints on http.DefaultServeMux, which can lead to information disclosure if the default mux is exposed on public HTTP servers.
+**Learning:** Default multiplexers are risky. Cloud personalities entry points (cmd/tesseract/*/main.go) expose http.Server without explicitly configuring a dedicated mux, causing http.DefaultServeMux to be used with the registered debug endpoints exposed publicly.
+**Prevention:** Avoid blank imports of net/http/pprof and expvar in production application entry points unless bound to an internal-only port or a specific mux.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Blank imports of `net/http/pprof` and `expvar` automatically register sensitive debug and metrics endpoints on `http.DefaultServeMux`. Cloud personality HTTP servers were using this default mux without restriction, exposing these endpoints publicly (CWE-200).
🎯 **Impact:** Exposes internal runtime metrics, memory profiles, CPU profiles, and BadgerDB metrics to unauthenticated users, leading to information disclosure and potential Denial of Service (DoS) attacks via expensive profiling requests.
🔧 **Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
✅ **Verification:** Verified by running `grep -r "net/http/pprof" cmd/tesseract/` and `grep -r "expvar" cmd/tesseract/` to ensure the imports are removed, and passing the full test suite (`go test ./... -short`).

---
*PR created automatically by Jules for task [10148644275846603095](https://jules.google.com/task/10148644275846603095) started by @phbnf*