### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 by removing exposed pprof/expvar endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-12 - Prevent Profiling Endpoints Exposure
+**Vulnerability:** The application was anonymously importing `net/http/pprof` and `expvar` in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This automatically exposes profiling and diagnostic endpoints on `http.DefaultServeMux` (e.g., `/debug/pprof/*` and `/debug/vars`). This exposes sensitive performance and state metrics, potentially leading to information disclosure (CWE-200).
+**Learning:** Anonymous imports that register endpoints on the default mux are risky and can inadvertently expose administrative/diagnostic panels publicly if the application binds its public-facing server to the default mux or if these endpoints aren't strictly gated.
+**Prevention:** Avoid anonymous imports for `net/http/pprof` and `expvar` in production binaries. If these endpoints are needed, intentionally mount them on an internal administrative mux bound to a different local port (e.g., `localhost:8081`).

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removed anonymous imports of `net/http/pprof` and `expvar` in `posix` and `gcp` entrypoints. These modules automatically register endpoints on `http.DefaultServeMux`, which could inadvertently expose sensitive profiling data.

---
*PR created automatically by Jules for task [14316848464122266996](https://jules.google.com/task/14316848464122266996) started by @phbnf*