### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-13 - [HIGH] Fix Profiling Endpoint Exposure
+**Vulnerability:** The `net/http/pprof` and `expvar` packages were imported in the cloud personality binaries (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`). This automatically registers profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints on the globally exposed `http.DefaultServeMux`, leading to a CWE-200 Information Exposure vulnerability.
+**Learning:** Using anonymous imports for `net/http/pprof` or `expvar` in binaries with public-facing HTTP servers inadvertently exposes sensitive internal state. These should never be imported unless explicitly bound to a private/internal mux.
+**Prevention:** Avoid `_ "net/http/pprof"` and `_ "expvar"` imports in public HTTP servers. Use OpenTelemetry for metrics instead, or explicitly mount them on a separate, unexposed administrative mux.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
## 🚨 Severity
HIGH

## 💡 Vulnerability
The `net/http/pprof` and `expvar` packages were being imported in the cloud personality binaries (`cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`). Using anonymous imports for these packages automatically registers debugging, profiling (`/debug/pprof/*`), and metrics (`/debug/vars`) endpoints on the globally exposed `http.DefaultServeMux`.

## 🎯 Impact
If a public-facing HTTP server relies on the default multiplexer, this inadvertently exposes sensitive application state to the internet, including memory heaps, goroutine stack traces, command-line variables, and BadgerDB metrics. This is a CWE-200 Information Exposure vulnerability.

## 🔧 Fix
Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. 

## ✅ Verification
- Run tests: `go test ./... -short` (All pass)
- Verify `net/http/pprof` and `expvar` no longer appear in the binary entrypoints.

---
*PR created automatically by Jules for task [8620827948298169276](https://jules.google.com/task/8620827948298169276) started by @phbnf*