### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar profiling endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,10 @@
+## 2026-06-14 - Prevent CWE-200 Information Exposure via Anonymous HTTP Handlers
+
+**Vulnerability:**
+The `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go` files included anonymous imports for `net/http/pprof` and `expvar`. These imports automatically bind their handlers to `http.DefaultServeMux`. If `http.DefaultServeMux` is exposed, this causes CWE-200 (Information Exposure), revealing sensitive profiling and metric information publicly without authentication.
+
+**Learning:**
+Anonymous imports of diagnostic or metric libraries such as `_ "net/http/pprof"` or `_ "expvar"` are dangerous because they mutate global state (`http.DefaultServeMux`) implicitly. In production or cloud personalities, relying on OpenTelemetry or other explicit metric bindings is preferred, avoiding unintended endpoint exposure.
+
+**Prevention:**
+Avoid `_ "net/http/pprof"` or `_ "expvar"` imports in binary entry points (`main.go`). If profiling or metric endpoints are needed, bind them explicitly to an internal, secured mux that is not exposed to public traffic. Check for similar issues using static analysis scanners and code reviews targeting anonymous imports.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Accidental exposure of profiling and metric endpoints (CWE-200) via anonymous imports (`net/http/pprof`, `expvar`).
🎯 Impact: Attackers or unauthorized users could access `/debug/pprof/*` or `/debug/vars`, revealing sensitive application memory, behavior, and metric data.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` imports from binary entry points.
✅ Verification: Build succeeds, and test suite passes. Also explicitly documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16126703893468769861](https://jules.google.com/task/16126703893468769861) started by @phbnf*