### PR TITLE
🛡️ Sentinel: [HIGH] Fix Information Exposure via Profiling Endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-06-16 - Prevent Profiling Endpoint Exposure in Public Entry Points
+
+**Vulnerability:** Anonymous imports of `net/http/pprof` (in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`) and `expvar` (in `cmd/tesseract/posix/main.go`) automatically expose profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the global `http.DefaultServeMux`. If `http.DefaultServeMux` is used or accessible publicly, this exposes internal application details, leading to a CWE-200 (Information Exposure) vulnerability.
+
+**Learning:** When creating cloud personalities or public-facing HTTP servers, it is crucial to avoid anonymous imports that mutate the default multiplexer. These endpoints provide valuable insight into the application's runtime state, which can be leveraged by attackers for reconnaissance or denial-of-service (DoS) attacks.
+
+**Prevention:** Never use anonymous imports like `_ "net/http/pprof"` or `_ "expvar"` in entry points that start HTTP servers for public API access. If profiling is strictly required, it should be bound to a separate, internal administrative server or port, not the public-facing listener.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
Removes anonymous profiling and debugging imports from public HTTP entry points.

---
*PR created automatically by Jules for task [15562401835227428276](https://jules.google.com/task/15562401835227428276) started by @phbnf*