### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 by removing anonymous pprof and expvar imports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - CWE-200: Profiling and Metrics Endpoint Exposure via DefaultServeMux
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` expose sensitive profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on the globally accessible `http.DefaultServeMux`.
+**Learning:** Using `http.DefaultServeMux` (by passing `nil` as the handler or omitting `Handler` in `http.Server`) makes the application vulnerable to exposing any endpoints registered by imported packages, particularly `pprof` and `expvar`.
+**Prevention:** Avoid using anonymous imports for `pprof` and `expvar` in production entry points. Use custom `http.ServeMux` instances instead of the default multiplexer to ensure only explicitly registered routes are exposed.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** CWE-200: Exposure of Sensitive Information to an Unauthorized Actor. Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling and metrics endpoints on `http.DefaultServeMux`. If `http.DefaultServeMux` is used without appropriate safeguards (e.g. passing `nil` to `http.ListenAndServe` or omitting a handler in `http.Server`), sensitive internal state and metrics can be exposed to unauthenticated users on the public interface.
🎯 **Impact:** Exposing `/debug/pprof/*` allows attackers to download memory profiles, CPU profiles, and potentially inspect application state or environment variables. Exposing `/debug/vars` leaks internal metrics and configurations (like BadgerDB metrics). This aids reconnaissance and can lead to more severe exploits.
🔧 **Fix:** Removed `_ "net/http/pprof"` from `cmd/tesseract/gcp/main.go` and removed `_ "net/http/pprof"` and `_ "expvar"` from `cmd/tesseract/posix/main.go`. Additionally, logged this architectural vulnerability pattern to `.jules/sentinel.md` as instructed.
✅ **Verification:** Verify that `grep -rn 'pprof\|expvar' .` yields no results for anonymous imports in the binaries. Tests have been run and passed successfully.

---
*PR created automatically by Jules for task [1877607874290985114](https://jules.google.com/task/1877607874290985114) started by @phbnf*