### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-200 /debug/pprof and /debug/vars Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,12 @@
+# Sentinel Journal
+
+## 2025-02-18 - CWE-200 /debug/vars Exposure
+
+**Vulnerability:**
+The POSIX binary imports `_ "expvar" // Registers /debug/vars, with BadgerDB metrics.` which registers `expvar` handlers to `http.DefaultServeMux`. Similarly, the GCP binary has `_ "net/http/pprof"` exposing profiling data via `http.DefaultServeMux`. Since these servers bind their API endpoints to `http.DefaultServeMux` (e.g. `http.Handle("/", otelhttp.NewHandler(logHandler, "/"))`), this makes `/debug/vars` and `/debug/pprof/*` publicly accessible.
+
+**Learning:**
+Anonymous imports like `_ "expvar"` and `_ "net/http/pprof"` automatically register routes on `http.DefaultServeMux`. If an application uses `http.DefaultServeMux` (e.g., via `http.Handle` or `http.ListenAndServe(..., nil)` or when setting `http.Server.Handler` implicitly to `nil`) for its public API, these debug endpoints are inadvertently exposed. This constitutes a CWE-200 Information Exposure.
+
+**Prevention:**
+Remove the anonymous imports of `expvar` and `net/http/pprof`. If profiling or metrics are needed, they should be explicitly registered on a separate internal multiplexer or port that is not accessible from the public internet.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
This commit resolves a CWE-200 vulnerability where anonymous imports of `net/http/pprof` and `expvar` inadvertently registered internal debugging and profiling handlers to `http.DefaultServeMux`. Because `http.DefaultServeMux` is used for the public-facing API endpoints, this exposed sensitive application data to the public.

To fix this, the imports have been removed. If these routes are needed for production analysis in the future, they should be securely served on an internal-only port.

A new entry was also added to `.jules/sentinel.md` documenting this finding and learning.

---
*PR created automatically by Jules for task [8592263366346729139](https://jules.google.com/task/8592263366346729139) started by @phbnf*