### PR TITLE
🛡️ Sentinel: [HIGH] Fix pprof and expvar profiling endpoint exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-23 - Remove pprof and expvar from cloud personalities
+**Vulnerability:** Profiling and metric endpoints were exposed via anonymous imports of `net/http/pprof` and `expvar` in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This inadvertently exposed sensitive application state and operational data at `/debug/pprof/*` and `/debug/vars` on `http.DefaultServeMux` (CWE-200).
+**Learning:** Anonymous imports that register handlers on the global `http.DefaultServeMux` must be strictly avoided, especially in cloud or public-facing HTTP server binaries, as they expose administrative details to unauthorized users.
+**Prevention:** Avoid `_ "net/http/pprof"` and `_ "expvar"` imports in application entry points. Instead, utilize structured telemetry (e.g., OpenTelemetry) to capture metrics and traces without exposing direct HTTP endpoints.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Profiling and metric endpoints were exposed via anonymous imports of `net/http/pprof` and `expvar` in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`. This inadvertently exposes sensitive application state and operational data at `/debug/pprof/*` and `/debug/vars` on `http.DefaultServeMux` (CWE-200).
🎯 Impact: Attackers could access `/debug/pprof/*` and `/debug/vars` to gain sensitive insights into the application's internal state, memory, CPU usage, and database metrics, aiding in further attacks or causing denial of service by triggering expensive profiling operations.
🔧 Fix: Removed `_ "net/http/pprof"` and `_ "expvar"` imports from the cloud personality entry points.
✅ Verification: Ran `grep -n "pprof" cmd/tesseract/posix/main.go` and `grep -n "pprof" cmd/tesseract/gcp/main.go` to confirm removal. Ran tests to ensure no regressions. Also added a journal entry in `.jules/sentinel.md` detailing this learning.

---
*PR created automatically by Jules for task [5980867403738566820](https://jules.google.com/task/5980867403738566820) started by @phbnf*