### PR TITLE
🛡️ Sentinel: [HIGH] Fix exposure of pprof and expvar profiling endpoints (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-25 - [Fix exposure of profiling endpoints]
+**Vulnerability:** Profiling endpoints (`/debug/pprof` and `/debug/vars`) are automatically exposed on the globally accessible `http.DefaultServeMux` due to anonymous imports of `net/http/pprof` and `expvar` in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. This leads to a CWE-200 vulnerability.
+**Learning:** Anonymous imports of standard library profiling packages (`net/http/pprof` and `expvar`) silently bind their endpoints to the global `http.DefaultServeMux`, making them accessible to anyone if that mux is served publicly.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in production binaries. If profiling is required, use OpenTelemetry (which is already utilized by the cloud personalities) or bind these endpoints to a restricted, internal administrative server.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Anonymous imports of standard library profiling packages (`net/http/pprof` and `expvar`) silently bind their endpoints (`/debug/pprof/*` and `/debug/vars`) to the global `http.DefaultServeMux`. In production binaries like `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`, this inadvertently exposes sensitive runtime profiling data, memory statistics, and command-line arguments to unauthenticated users, leading to a CWE-200 (Information Exposure) vulnerability.
🎯 **Impact**: Potential attackers could access sensitive runtime metrics and internal state, which can be leveraged for reconnaissance and planning further attacks.
🔧 **Fix**: Removed the anonymous `_ "net/http/pprof"` and `_ "expvar"` imports from the `main.go` files of the `gcp` and `posix` personalities. OpenTelemetry is already configured for observability across these binaries.
✅ **Verification**: Run `go test ./... -short` and verify that the application compiles successfully with `go build ./...`. A new file `.jules/sentinel.md` has been created documenting this finding.

---
*PR created automatically by Jules for task [14256580673402773863](https://jules.google.com/task/14256580673402773863) started by @phbnf*