### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Profiling Endpoint Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-26 - CWE-200: Profiling Endpoint Exposure via Anonymous Imports
+**Vulnerability:** The POSIX and GCP cloud personality entry points inadvertently exposed profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) on `http.DefaultServeMux` by importing `_ "net/http/pprof"` and `_ "expvar"`.
+**Learning:** Anonymous imports of these packages automatically register their HTTP handlers on the global multiplexer. In cloud-specific deployments running HTTP servers, this exposes sensitive internal performance data and system metrics to the public.
+**Prevention:** Do not use anonymous imports for `net/http/pprof` or `expvar` in production HTTP server entry points. Cloud personalities should utilize OpenTelemetry (otel) for observability, avoiding reliance on globally exposed debug endpoints.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The GCP and POSIX cloud personality binaries inadvertently exposed internal profiling, memory metrics, and variables on `http.DefaultServeMux` by anonymously importing `net/http/pprof` and `expvar`.
🎯 Impact: An attacker could access sensitive application performance data, execution profiles, and system variables (CWE-200).
🔧 Fix: Removed the anonymous imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ Verification: Ensure the binaries compile and run `go test ./... -short`. Profiling endpoints will no longer be available at `/debug/pprof/*`.

---
*PR created automatically by Jules for task [7241207045179436931](https://jules.google.com/task/7241207045179436931) started by @phbnf*