### PR TITLE
🛡️ Sentinel: [HIGH] Fix Information Exposure (CWE-200) via Debug Endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-15 - [Information Exposure]
+**Vulnerability:** Information Exposure (CWE-200) via exposed profiling and debug endpoints in production cloud deployments. The blank imports `_ "net/http/pprof"` and `_ "expvar"` automatically register diagnostic handlers on `http.DefaultServeMux`, which gets exposed on the default HTTP port.
+**Learning:** These endpoints can expose sensitive internal metrics, configuration, and source details to an attacker. Debug endpoints should never be blindly exposed to external networks in production environments.
+**Prevention:** Avoid blank imports of `net/http/pprof` or `expvar` in production entry points. For debugging and metrics, specifically bind them to loopback interfaces, require authentication/authorization, or use a separate dedicated, protected port/multiplexer.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Information Exposure (CWE-200) via exposed profiling and debug endpoints in production cloud deployments. The blank imports `_ "net/http/pprof"` and `_ "expvar"` automatically register diagnostic handlers on `http.DefaultServeMux`.
🎯 **Impact:** Exposes sensitive internal metrics, configuration, and source details to an attacker.
🔧 **Fix:** Removed the blank imports of `net/http/pprof` and `expvar` from the GCP and POSIX production entry points.
✅ **Verification:** Verified by building all packages (`go build ./...`) and ensuring tests pass (`go test ./... -short`). A new entry was added to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [366361697770989551](https://jules.google.com/task/366361697770989551) started by @phbnf*