### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 by removing net/http/pprof and expvar imports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,10 @@
+## 2025-02-23 - Prevent Exposing Profiling and Metrics Endpoints
+
+**Vulnerability:**
+The `net/http/pprof` and `expvar` packages were imported using `_` in the main application entry points (`cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`). This automatically registers profiling (`/debug/pprof/*`) and metrics (`/debug/vars`) endpoints on the global `http.DefaultServeMux`. If an application uses `http.DefaultServeMux` or inadvertently exposes it, these endpoints can become publicly accessible, leading to a CWE-200 (Exposure of Sensitive Information to an Unauthorized Actor) vulnerability, which may reveal internal application state, memory profiles, and BadgerDB metrics.
+
+**Learning:**
+Anonymous imports (`_ "package"`) of debugging and profiling tools in production binaries introduce a significant risk by binding handlers to the default global multiplexer, which might be unintentionally exposed via public-facing servers.
+
+**Prevention:**
+Avoid importing `net/http/pprof` and `expvar` in production entry points. If profiling or metrics are required, explicitly register their handlers on a separate, internal-only `http.ServeMux` or use dedicated observability platforms (like OpenTelemetry) that do not rely on global HTTP handler registration.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `net/http/pprof` and `expvar` packages were imported anonymously (`_ "net/http/pprof"`), which automatically registers debugging and profiling endpoints on the global `http.DefaultServeMux`.
🎯 Impact: If the default mux is inadvertently exposed to a public-facing network interface, these endpoints become accessible to unauthorized actors, exposing sensitive internal state, memory profiles, and database metrics (CWE-200).
🔧 Fix: Removed the anonymous imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ Verification: `go test ./... -short` passes, and the imports no longer exist in the codebase.

---
*PR created automatically by Jules for task [5201255780002608797](https://jules.google.com/task/5201255780002608797) started by @phbnf*