### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 Information Exposure in Cloud Personalities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-29 - [Fix CWE-200 in Cloud Personalities]
+**Vulnerability:** The `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` files contained anonymous imports for `net/http/pprof` and `expvar`. This exposed the `/debug/pprof/*` and `/debug/vars` endpoints on the global `http.DefaultServeMux`, leading to CWE-200 Information Exposure.
+**Learning:** These entry points should avoid using `net/http/pprof` and `expvar` because `http.DefaultServeMux` is generally exposed in HTTP server entry points.
+**Prevention:** Cloud personalities utilize OpenTelemetry (otel) for handlers and deliberately avoid exposing `net/http/pprof` endpoints. Avoid anonymous imports for metrics and profiling on public-facing multiplexers.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` files contained anonymous imports for `net/http/pprof` and `expvar`. This exposed the `/debug/pprof/*` and `/debug/vars` endpoints on the global `http.DefaultServeMux`, leading to CWE-200 Information Exposure.
🎯 Impact: An attacker could access sensitive internal memory profiles, metrics, and application state if these multiplexers are exposed to the internet.
🔧 Fix: Removed the anonymous imports for `net/http/pprof` and `expvar`. 
✅ Verification: Ensure the `net/http/pprof` and `expvar` imports no longer exist in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.

---
*PR created automatically by Jules for task [1808600442462054849](https://jules.google.com/task/1808600442462054849) started by @phbnf*