### PR TITLE
🛡️ Sentinel: [HIGH] Fix Profiling and Metrics Endpoint Exposure (CWE-200)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Profiling and Metrics Endpoint Exposure (CWE-200)
+**Vulnerability:** Profiling and metrics endpoints (`/debug/pprof/*` and `/debug/vars`) were exposed on the global `http.DefaultServeMux` via anonymous imports of `net/http/pprof` and `expvar` in the `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` entry points.
+**Learning:** Importing these packages registers their endpoints globally. Because the cloud personality HTTP servers (which serve public requests) are sometimes configured to use or fallback to the `http.DefaultServeMux`, this exposes sensitive internal performance metrics and profiling data to unauthorized external users, leading to an Information Exposure (CWE-200).
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in production entry points. If profiling or metrics are required, explicitly register them on a dedicated, internal-only `http.ServeMux` bound to a separate, private network interface.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` in the `gcp` and `posix` cloud personality entry points implicitly register profiling and metrics endpoints on `http.DefaultServeMux`. This exposes sensitive internal performance data and environment variables to the public internet (CWE-200).
🎯 **Impact:** Unauthorized external users could access profiling endpoints (`/debug/pprof/*`) and metrics endpoints (`/debug/vars`), leaking sensitive internal application state and performance characteristics.
🔧 **Fix:** Removed the anonymous imports of `net/http/pprof` and `expvar` in `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ **Verification:** Verified via `gosec` that the G108 (Profiling endpoint is automatically exposed on /debug/pprof) warnings are resolved. Verified tests pass. Added journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18212556433760162182](https://jules.google.com/task/18212556433760162182) started by @phbnf*