### PR TITLE
🛡️ Sentinel: [HIGH] Remove profiling endpoints from POSIX and GCP personalities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Unintentional Exposure of Profiling and Metrics Endpoints
+**Vulnerability:** Profiling (`net/http/pprof`) and metrics (`expvar`) endpoints were exposed due to anonymous imports in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
+**Learning:** Anonymous imports of these packages automatically register handlers on `http.DefaultServeMux`. If `http.DefaultServeMux` is used or exposed without proper authentication or network segmentation, sensitive internal state and performance data can be leaked to unauthorized users (CWE-200).
+**Prevention:** Avoid anonymous imports of `net/http/pprof` and `expvar` in production binaries. If profiling or metrics are required, explicitly register them on a dedicated, internal-only `ServeMux` that is securely authenticated or isolated from public access.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -45,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Remove profiling endpoints from POSIX and GCP personalities

**Severity:** HIGH (CWE-200)
**Vulnerability:** Profiling (`net/http/pprof`) and metrics (`expvar`) endpoints were exposed due to anonymous imports in `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go`.
**Impact:** Anonymous imports of these packages automatically register handlers on `http.DefaultServeMux`. If `http.DefaultServeMux` is used or exposed without proper authentication or network segmentation, sensitive internal state and performance data can be leaked to unauthorized users.
**Fix:** Removed the anonymous imports from the entry point files.
**Verification:** Ran `go test ./... -short` to ensure functionality is not broken and `go build` to ensure the binaries compile correctly.

---
*PR created automatically by Jules for task [10047809697756038374](https://jules.google.com/task/10047809697756038374) started by @phbnf*