### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CWE-200 DefaultServeMux Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-07-04 - HTTP DefaultServeMux Exposure (CWE-200)
+**Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling and BadgerDB metrics endpoints on the global `http.DefaultServeMux`. If `http.ListenAndServe()` or an `http.Server` handles requests without properly sandboxing the DefaultServeMux, these endpoints become exposed to the public.
+**Learning:** Even if `tesseract` uses a custom handler for most routes, importing `_ "net/http/pprof"` and `_ "expvar"` in binaries like `cmd/tesseract/posix/main.go` and `cmd/tesseract/gcp/main.go` registers dangerous profiling endpoints `/debug/pprof/*` and `/debug/vars` globally.
+**Prevention:** Do not use anonymous imports for `net/http/pprof` or `expvar` in public-facing binaries. If profiling or metrics are required, explicitly attach them to an internal, authenticated, or bound-to-localhost multiplexer.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Anonymous imports of `net/http/pprof` and `expvar` automatically register profiling and BadgerDB metrics endpoints on the global `http.DefaultServeMux`. This exposes internal profiling data, metrics, and potentially environment variables to the public. (CWE-200: Exposure of Sensitive Information to an Unauthorized Actor).
🎯 **Impact:** If exploited, attackers can gain insight into the application's internal state, memory usage, running goroutines, and potentially extract sensitive environment variables, aiding further attacks.
🔧 **Fix:** Removed the `_ "net/http/pprof"` and `_ "expvar"` imports from the public-facing binaries `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`.
✅ **Verification:** Verified by checking that the imports are no longer present in the files and ensuring all tests pass (`go test ./... -short`). A journal entry documenting this finding was added to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4481961718648892043](https://jules.google.com/task/4481961718648892043) started by @phbnf*