### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-200 profiling and metrics endpoints exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-07-05 - [HIGH] Fix CWE-200 profiling and metrics endpoints exposure
+**Vulnerability:** Profiling (`net/http/pprof`) and metrics (`expvar`) endpoints were exposed via anonymous imports on `http.DefaultServeMux` in the `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` binaries. This could lead to CWE-200 Information Exposure.
+**Learning:** Anonymous imports of `net/http/pprof` or `expvar` automatically register handlers on `http.DefaultServeMux`. If `http.ListenAndServe()` is used, this exposes these endpoints on any interface unless specifically restricted or handled correctly on a custom multiplexer.
+**Prevention:** Avoid anonymous imports of `net/http/pprof` or `expvar` in production binaries to prevent inadvertent exposure of diagnostic endpoints.

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"os/signal"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -44,8 +43,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-
-	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
 
 func init() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Profiling (`net/http/pprof`) and metrics (`expvar`) endpoints were exposed via anonymous imports on `http.DefaultServeMux` in the `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go` binaries. This could lead to CWE-200 Information Exposure.
🎯 Impact: An attacker could access `/debug/pprof` and `/debug/vars` to view memory profiles, internal application state, and potentially sensitive metrics, aiding in further exploitation or reconnaissance.
🔧 Fix: Removed the anonymous imports from `cmd/tesseract/gcp/main.go` and `cmd/tesseract/posix/main.go`. Added a journal entry to `.jules/sentinel.md` documenting this finding.
✅ Verification: Review the code to ensure `_ "net/http/pprof"` and `_ "expvar"` are no longer imported in those binaries. Test suite `go test ./... -short` passes.

---
*PR created automatically by Jules for task [7361342704147051318](https://jules.google.com/task/7361342704147051318) started by @phbnf*